### PR TITLE
[codex] Add schema-backed assistant types

### DIFF
--- a/frontend/client/AssistantClient.ts
+++ b/frontend/client/AssistantClient.ts
@@ -2,7 +2,12 @@ import axios from "axios";
 
 import type {
   AssistantModel,
+  AssistantResponse,
   AssistantTemperature,
+} from "@/client/types/assistant";
+import {
+  assistantRequestSchema,
+  assistantResponseSchema,
 } from "@/client/types/assistant";
 import { logger } from "@/logger";
 
@@ -13,15 +18,14 @@ export default async function fetchAssistantResponse(
   model: AssistantModel,
   temperature: AssistantTemperature,
   prompt: string
-) {
+): Promise<AssistantResponse> {
   const fullUrl = `${url}/api/v1/chat/${model}/?temperature=${temperature}`;
+  const request = assistantRequestSchema.parse({ prompt });
 
   log.info(`Model: ${model}, Temperature: ${temperature}, Prompt: ${prompt}`);
   log.info(`Fetching assistant response from ${fullUrl}`);
 
-  const response = await axios.post(fullUrl, {
-    prompt,
-  });
+  const response = await axios.post<unknown>(fullUrl, request);
 
-  return response.data;
+  return assistantResponseSchema.parse(response.data);
 }

--- a/frontend/client/hooks/useAssistantResponse.ts
+++ b/frontend/client/hooks/useAssistantResponse.ts
@@ -2,6 +2,7 @@ import useSWRMutation from "swr/mutation";
 
 import type {
   AssistantModel,
+  AssistantResponse,
   AssistantTemperature,
 } from "@/client/types/assistant";
 
@@ -14,15 +15,18 @@ interface AssistantResponseArgs {
 }
 
 export default function useAssistantResponse() {
-  const { trigger, data, error, isMutating } = useSWRMutation(
-    "assistant-response", // A unique key for the mutation
-    (_, { arg }: { arg: AssistantResponseArgs }) =>
-      fetchAssistantResponse(
-        "http://localhost:8000",
-        arg.model,
-        arg.temperature,
-        arg.prompt
-      )
+  const { trigger, data, error, isMutating } = useSWRMutation<
+    AssistantResponse,
+    Error,
+    string,
+    AssistantResponseArgs
+  >("assistant-response", (_, { arg }) =>
+    fetchAssistantResponse(
+      "http://localhost:8000",
+      arg.model,
+      arg.temperature,
+      arg.prompt
+    )
   );
 
   return {

--- a/frontend/client/types/assistant.test.ts
+++ b/frontend/client/types/assistant.test.ts
@@ -1,0 +1,35 @@
+import {
+  AssistantModel,
+  AssistantTemperature,
+  assistantModelSchema,
+  assistantRequestSchema,
+  assistantResponseSchema,
+  assistantTemperatureSchema,
+} from "./assistant";
+
+describe("assistant schemas", () => {
+  it("accepts supported assistant model and temperature values", () => {
+    expect(assistantModelSchema.parse(AssistantModel.FULL)).toBe(
+      AssistantModel.FULL
+    );
+    expect(
+      assistantTemperatureSchema.parse(AssistantTemperature.BALANCED)
+    ).toBe(AssistantTemperature.BALANCED);
+  });
+
+  it("validates outgoing assistant requests", () => {
+    expect(assistantRequestSchema.parse({ prompt: "Hello" })).toEqual({
+      prompt: "Hello",
+    });
+    expect(() => assistantRequestSchema.parse({ prompt: "" })).toThrow();
+  });
+
+  it("validates assistant responses strictly", () => {
+    expect(assistantResponseSchema.parse({ response: "Hello" })).toEqual({
+      response: "Hello",
+    });
+    expect(() =>
+      assistantResponseSchema.parse({ response: "Hello", extra: true })
+    ).toThrow();
+  });
+});

--- a/frontend/client/types/assistant.ts
+++ b/frontend/client/types/assistant.ts
@@ -1,12 +1,32 @@
-enum AssistantTemperature {
-  DETERMINISTIC = "DETERMINISTIC", // 0.2 - More Deterministic
-  BALANCED = "BALANCED", // 0.7 - Balanced
-  CREATIVE = "CREATIVE", // 0.9 - More Creative
-}
+import { z } from "zod";
 
-enum AssistantModel {
-  FULL = "gpt-4o",
-  MINI = "gpt-4o-mini",
-}
+export const assistantModelSchema = z.enum(["gpt-4o", "gpt-4o-mini"]);
+export type AssistantModel = z.infer<typeof assistantModelSchema>;
 
-export { AssistantTemperature, AssistantModel };
+export const AssistantModel = {
+  FULL: "gpt-4o",
+  MINI: "gpt-4o-mini",
+} as const satisfies Record<string, AssistantModel>;
+
+export const assistantTemperatureSchema = z.enum([
+  "DETERMINISTIC", // 0.2 - More Deterministic
+  "BALANCED", // 0.7 - Balanced
+  "CREATIVE", // 0.9 - More Creative
+]);
+export type AssistantTemperature = z.infer<typeof assistantTemperatureSchema>;
+
+export const AssistantTemperature = {
+  DETERMINISTIC: "DETERMINISTIC",
+  BALANCED: "BALANCED",
+  CREATIVE: "CREATIVE",
+} as const satisfies Record<string, AssistantTemperature>;
+
+export const assistantRequestSchema = z.strictObject({
+  prompt: z.string().min(1),
+});
+export type AssistantRequest = z.infer<typeof assistantRequestSchema>;
+
+export const assistantResponseSchema = z.strictObject({
+  response: z.string(),
+});
+export type AssistantResponse = z.infer<typeof assistantResponseSchema>;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,8 @@
         "react-dom": "^19",
         "react-markdown": "^10.1.0",
         "swr": "^2.4.1",
-        "uuid": "^14.0.0"
+        "uuid": "^14.0.0",
+        "zod": "^4.4.1"
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.13",
@@ -9999,6 +10000,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
+      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,8 @@
     "react-dom": "^19",
     "react-markdown": "^10.1.0",
     "swr": "^2.4.1",
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "zod": "^4.4.1"
   },
   "browserList": {
     "production": [">0.2%", "not dead", "not op_mini all"],


### PR DESCRIPTION
## Summary

- Add Zod schemas for assistant model, temperature, request, and response contracts.
- Infer TypeScript types from those schemas so runtime validation and static typing share one source of truth.
- Parse outgoing assistant requests and incoming Axios response data at the API boundary before UI/SWR code consumes them.
- Add focused schema tests covering accepted values, prompt validation, and strict response parsing.

## Context

This follows the `parse-dont-pray` guidance to validate external data at trust boundaries and derive types from schemas instead of trusting unchecked response shapes.

## Validation

- `npm run check-types`
- `npx biome check client/types/assistant.ts client/types/assistant.test.ts client/AssistantClient.ts client/hooks/useAssistantResponse.ts`
- `npm test -- --runInBand`
- `npm run build` passed; Next.js rewrote `frontend/tsconfig.json` during the build, and that generated config change was restored before committing.

## Notes

- `npm audit --audit-level=moderate` still fails on the existing dependency baseline (`diff`, `postcss` via `next`, and `prismjs` via `react-code-blocks`/`react-syntax-highlighter`), not on the new Zod dependency.
