### PR TITLE
docs: add agent instruction files for Claude, Gemini, and Copilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,8 @@ docker-compose up    # run via Docker
 
 ## Constraints
 
-- Backend test coverage must stay ≥ 95%; frontend at 100%.
+- Backend test coverage must stay ≥ 95%; frontend ≥ 90% statements/functions/lines
+  and ≥ 75% branches.
 - Type annotation coverage must be 100% on both sides.
 - File names must pass `ls-lint` (`make file-naming`).
 - Pre-commit hooks enforced via `prek` — run `make hooks` to check all files.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,44 @@
+# Agents
+
+Minimal full-stack chatbot: React frontend + FastAPI backend, streamed via Azure OpenAI GPT-4o.
+
+## Architecture
+
+```
+frontend/   React + Vite + Vercel AI SDK + Material UI
+server/     FastAPI + openai + loguru
+```
+
+## Setup
+
+```bash
+# Backend
+cd server && uv sync --frozen
+
+# Frontend
+cd frontend && pnpm install --frozen-lockfile
+```
+
+Requires `server/.env` (see `server/.env.example`).
+
+## Commands
+
+```bash
+make qa              # full quality suite (format, lint, type-check, test, coverage)
+make test            # unit tests only
+make format          # auto-format all code
+make lint            # lint all code
+make type-check      # static type checking
+make run             # start both servers locally
+docker-compose up    # run via Docker
+```
+
+Frontend: `http://localhost:3000` — Backend: `http://localhost:8000` — Swagger: `http://localhost:8000/docs`
+
+## Constraints
+
+- Backend test coverage must stay ≥ 95%; frontend at 100%.
+- Type annotation coverage must be 100% on both sides.
+- File names must pass `ls-lint` (`make file-naming`).
+- Pre-commit hooks enforced via `prek` — run `make hooks` to check all files.
+- Always run `make qa` before committing.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,11 @@
 # Agents
 
-Minimal full-stack chatbot: React frontend + FastAPI backend, streamed via Azure OpenAI GPT-4o.
+Minimal full-stack chatbot: React frontend + FastAPI backend,
+streamed via Azure OpenAI GPT-4o.
 
 ## Architecture
 
-```
+```text
 frontend/   React + Vite + Vercel AI SDK + Material UI
 server/     FastAPI + openai + loguru
 ```
@@ -33,7 +34,9 @@ make run             # start both servers locally
 docker-compose up    # run via Docker
 ```
 
-Frontend: `http://localhost:3000` — Backend: `http://localhost:8000` — Swagger: `http://localhost:8000/docs`
+- Frontend: `http://localhost:3000`
+- Backend: `http://localhost:8000`
+- Swagger: `http://localhost:8000/docs`
 
 ## Constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,8 @@ docker-compose up    # run via Docker
 
 ## Constraints
 
-- Backend test coverage must stay ≥ 95%; frontend at 100%.
+- Backend test coverage must stay ≥ 95%; frontend ≥ 90% statements/functions/lines
+  and ≥ 75% branches.
 - Type annotation coverage must be 100% on both sides.
 - File names must pass `ls-lint` (`make file-naming`).
 - Pre-commit hooks enforced via `prek` — run `make hooks` to check all files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# Agents
+
+Minimal full-stack chatbot: React frontend + FastAPI backend, streamed via Azure OpenAI GPT-4o.
+
+## Architecture
+
+```
+frontend/   React + Vite + Vercel AI SDK + Material UI
+server/     FastAPI + openai + loguru
+```
+
+## Setup
+
+```bash
+# Backend
+cd server && uv sync --frozen
+
+# Frontend
+cd frontend && pnpm install --frozen-lockfile
+```
+
+Requires `server/.env` (see `server/.env.example`).
+
+## Commands
+
+```bash
+make qa              # full quality suite (format, lint, type-check, test, coverage)
+make test            # unit tests only
+make format          # auto-format all code
+make lint            # lint all code
+make type-check      # static type checking
+make run             # start both servers locally
+docker-compose up    # run via Docker
+```
+
+Frontend: `http://localhost:3000` — Backend: `http://localhost:8000` — Swagger: `http://localhost:8000/docs`
+
+## Constraints
+
+- Backend test coverage must stay ≥ 95%; frontend at 100%.
+- Type annotation coverage must be 100% on both sides.
+- File names must pass `ls-lint` (`make file-naming`).
+- Pre-commit hooks enforced via `prek` — run `make hooks` to check all files.
+- Always run `make qa` before committing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,11 @@
 # Agents
 
-Minimal full-stack chatbot: React frontend + FastAPI backend, streamed via Azure OpenAI GPT-4o.
+Minimal full-stack chatbot: React frontend + FastAPI backend,
+streamed via Azure OpenAI GPT-4o.
 
 ## Architecture
 
-```
+```text
 frontend/   React + Vite + Vercel AI SDK + Material UI
 server/     FastAPI + openai + loguru
 ```
@@ -33,7 +34,9 @@ make run             # start both servers locally
 docker-compose up    # run via Docker
 ```
 
-Frontend: `http://localhost:3000` — Backend: `http://localhost:8000` — Swagger: `http://localhost:8000/docs`
+- Frontend: `http://localhost:3000`
+- Backend: `http://localhost:8000`
+- Swagger: `http://localhost:8000/docs`
 
 ## Constraints
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ docker-compose up    # run via Docker
 
 ## Constraints
 
-- Backend test coverage must stay ≥ 95%; frontend at 100%.
+- Backend test coverage must stay ≥ 95%; frontend ≥ 90% statements/functions/lines
+  and ≥ 75% branches.
 - Type annotation coverage must be 100% on both sides.
 - File names must pass `ls-lint` (`make file-naming`).
 - Pre-commit hooks enforced via `prek` — run `make hooks` to check all files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# Agents
+
+Minimal full-stack chatbot: React frontend + FastAPI backend, streamed via Azure OpenAI GPT-4o.
+
+## Architecture
+
+```
+frontend/   React + Vite + Vercel AI SDK + Material UI
+server/     FastAPI + openai + loguru
+```
+
+## Setup
+
+```bash
+# Backend
+cd server && uv sync --frozen
+
+# Frontend
+cd frontend && pnpm install --frozen-lockfile
+```
+
+Requires `server/.env` (see `server/.env.example`).
+
+## Commands
+
+```bash
+make qa              # full quality suite (format, lint, type-check, test, coverage)
+make test            # unit tests only
+make format          # auto-format all code
+make lint            # lint all code
+make type-check      # static type checking
+make run             # start both servers locally
+docker-compose up    # run via Docker
+```
+
+Frontend: `http://localhost:3000` — Backend: `http://localhost:8000` — Swagger: `http://localhost:8000/docs`
+
+## Constraints
+
+- Backend test coverage must stay ≥ 95%; frontend at 100%.
+- Type annotation coverage must be 100% on both sides.
+- File names must pass `ls-lint` (`make file-naming`).
+- Pre-commit hooks enforced via `prek` — run `make hooks` to check all files.
+- Always run `make qa` before committing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,11 @@
 # Agents
 
-Minimal full-stack chatbot: React frontend + FastAPI backend, streamed via Azure OpenAI GPT-4o.
+Minimal full-stack chatbot: React frontend + FastAPI backend,
+streamed via Azure OpenAI GPT-4o.
 
 ## Architecture
 
-```
+```text
 frontend/   React + Vite + Vercel AI SDK + Material UI
 server/     FastAPI + openai + loguru
 ```
@@ -33,7 +34,9 @@ make run             # start both servers locally
 docker-compose up    # run via Docker
 ```
 
-Frontend: `http://localhost:3000` — Backend: `http://localhost:8000` — Swagger: `http://localhost:8000/docs`
+- Frontend: `http://localhost:3000`
+- Backend: `http://localhost:8000`
+- Swagger: `http://localhost:8000/docs`
 
 ## Constraints
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -40,7 +40,8 @@ docker-compose up    # run via Docker
 
 ## Constraints
 
-- Backend test coverage must stay ≥ 95%; frontend at 100%.
+- Backend test coverage must stay ≥ 95%; frontend ≥ 90% statements/functions/lines
+  and ≥ 75% branches.
 - Type annotation coverage must be 100% on both sides.
 - File names must pass `ls-lint` (`make file-naming`).
 - Pre-commit hooks enforced via `prek` — run `make hooks` to check all files.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,44 @@
+# Agents
+
+Minimal full-stack chatbot: React frontend + FastAPI backend, streamed via Azure OpenAI GPT-4o.
+
+## Architecture
+
+```
+frontend/   React + Vite + Vercel AI SDK + Material UI
+server/     FastAPI + openai + loguru
+```
+
+## Setup
+
+```bash
+# Backend
+cd server && uv sync --frozen
+
+# Frontend
+cd frontend && pnpm install --frozen-lockfile
+```
+
+Requires `server/.env` (see `server/.env.example`).
+
+## Commands
+
+```bash
+make qa              # full quality suite (format, lint, type-check, test, coverage)
+make test            # unit tests only
+make format          # auto-format all code
+make lint            # lint all code
+make type-check      # static type checking
+make run             # start both servers locally
+docker-compose up    # run via Docker
+```
+
+Frontend: `http://localhost:3000` — Backend: `http://localhost:8000` — Swagger: `http://localhost:8000/docs`
+
+## Constraints
+
+- Backend test coverage must stay ≥ 95%; frontend at 100%.
+- Type annotation coverage must be 100% on both sides.
+- File names must pass `ls-lint` (`make file-naming`).
+- Pre-commit hooks enforced via `prek` — run `make hooks` to check all files.
+- Always run `make qa` before committing.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,10 +1,11 @@
 # Agents
 
-Minimal full-stack chatbot: React frontend + FastAPI backend, streamed via Azure OpenAI GPT-4o.
+Minimal full-stack chatbot: React frontend + FastAPI backend,
+streamed via Azure OpenAI GPT-4o.
 
 ## Architecture
 
-```
+```text
 frontend/   React + Vite + Vercel AI SDK + Material UI
 server/     FastAPI + openai + loguru
 ```
@@ -33,7 +34,9 @@ make run             # start both servers locally
 docker-compose up    # run via Docker
 ```
 
-Frontend: `http://localhost:3000` — Backend: `http://localhost:8000` — Swagger: `http://localhost:8000/docs`
+- Frontend: `http://localhost:3000`
+- Backend: `http://localhost:8000`
+- Swagger: `http://localhost:8000/docs`
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` as the canonical, minimal source of truth for AI agent instructions
- Propagates identical content to `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` so all agents see the same context
- Covers: project overview, architecture, setup commands, `make` targets, and hard constraints (coverage floors, type annotation requirements, `ls-lint` file naming, `prek` pre-commit hooks)

## Test plan

- [ ] Verify all four files are identical in content
- [ ] Confirm `.github/copilot-instructions.md` is picked up by GitHub Copilot in the repo