### PR TITLE
refactor: graceful exception handling with openai-specific error types

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -17,7 +17,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1  # v6.0.2
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d  # v6.0.5
         with:
           version: 11.0.3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,10 @@ jobs:
       - name: Upload backend coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: backend/coverage.xml
           flags: backend
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
       - name: Upload backend coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -76,9 +77,10 @@ jobs:
       - name: Upload frontend coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: frontend/coverage/lcov.info
           flags: frontend
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
       - name: Upload frontend coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,13 @@ jobs:
       - name: Run backend unit tests
         run: make backend-test
 
+      - name: Upload backend coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: backend/coverage.xml
+          flags: backend
+          fail_ci_if_error: true
+
       - name: Upload backend coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -65,6 +72,13 @@ jobs:
 
       - name: Run frontend unit tests
         run: make frontend-test
+
+      - name: Upload frontend coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: frontend/coverage/lcov.info
+          flags: frontend
+          fail_ci_if_error: true
 
       - name: Upload frontend coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: make backend-test
 
       - name: Upload backend coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: backend/coverage.xml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1  # v6.0.2
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d  # v6.0.5
         with:
           version: 11.0.3
 
@@ -75,7 +75,7 @@ jobs:
         run: make frontend-test
 
       - name: Upload frontend coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: frontend/coverage/lcov.info

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,73 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make
+
+      - name: Install backend dependencies
+        working-directory: ./backend
+        run: |
+          uv python install
+          uv sync --frozen
+
+      - name: Run backend unit tests
+        run: make backend-test
+
+      - name: Upload backend coverage report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: backend-coverage
+          path: backend/htmlcov
+
+  frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1  # v6.0.2
+        with:
+          version: 11.0.3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version-file: "frontend/.nvmrc"
+          cache: "pnpm"
+          cache-dependency-path: "frontend/pnpm-lock.yaml"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make
+
+      - name: Install frontend dependencies
+        working-directory: ./frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Run frontend unit tests
+        run: make frontend-test
+
+      - name: Upload frontend coverage report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: frontend-coverage
+          path: frontend/coverage

--- a/backend/app/azure_client.py
+++ b/backend/app/azure_client.py
@@ -53,11 +53,11 @@ def _create_openai_stream(
         raise
     except openai.APIConnectionError:
         logger.warning(
-            "Azure OpenAI connection failed — check network and endpoint settings"
+            "Azure OpenAI connection failed — check network and endpoint settings",
         )
         raise
-    except openai.APIStatusError as exc:
-        logger.error("Azure OpenAI returned HTTP {} creating stream", exc.status_code)
+    except openai.APIError:
+        logger.exception("Azure OpenAI API error creating stream")
         raise
 
 

--- a/backend/app/azure_client.py
+++ b/backend/app/azure_client.py
@@ -2,6 +2,7 @@ import time
 from functools import lru_cache
 from typing import TYPE_CHECKING, cast
 
+import openai
 from loguru import logger
 from openai import AzureOpenAI
 
@@ -30,6 +31,36 @@ def get_azure_openai_client() -> AzureOpenAI:
     )
 
 
+def _create_openai_stream(
+    client: AzureOpenAI,
+    *,
+    messages: Sequence[ChatMessage],
+    model: AssistantModel,
+    temperature: AssistantTemperature,
+) -> Stream[ChatCompletionChunk]:
+    try:
+        return client.chat.completions.create(
+            model=model.value,
+            temperature=temperature.openai_value,
+            messages=cast("Sequence[ChatCompletionMessageParam]", messages),
+            stream=True,
+        )
+    except openai.AuthenticationError:
+        logger.error("Azure OpenAI authentication failed — verify API key and endpoint")
+        raise
+    except openai.RateLimitError:
+        logger.warning("Azure OpenAI rate limit exceeded")
+        raise
+    except openai.APIConnectionError:
+        logger.warning(
+            "Azure OpenAI connection failed — check network and endpoint settings"
+        )
+        raise
+    except openai.APIStatusError as exc:
+        logger.error("Azure OpenAI returned HTTP {} creating stream", exc.status_code)
+        raise
+
+
 def stream_azure_openai_response(
     *,
     messages: Sequence[ChatMessage],
@@ -38,23 +69,29 @@ def stream_azure_openai_response(
 ) -> Iterator[str]:
     client: AzureOpenAI = get_azure_openai_client()
     start_time: float = time.time()
-
-    stream: Stream[ChatCompletionChunk] = client.chat.completions.create(
-        model=model.value,
-        temperature=temperature.openai_value,
-        messages=cast("Sequence[ChatCompletionMessageParam]", messages),
-        stream=True,
+    stream: Stream[ChatCompletionChunk] = _create_openai_stream(
+        client,
+        messages=messages,
+        model=model,
+        temperature=temperature,
     )
 
     total_length: int = 0
-    for chunk in stream:
-        if not chunk.choices:
-            continue
+    try:
+        for chunk in stream:
+            if not chunk.choices:
+                continue
 
-        content: str = chunk.choices[0].delta.content or ""
-        if content:
-            total_length += len(content)
-            yield content
+            content: str = chunk.choices[0].delta.content or ""
+            if content:
+                total_length += len(content)
+                yield content
+    except openai.APIError:
+        logger.exception(
+            "Azure OpenAI error during streaming after {} characters",
+            total_length,
+        )
+        raise
 
     logger.info(
         "Azure OpenAI streaming completion took {:.2f}s and returned {} characters",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Annotated, Literal
 
+import openai
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
@@ -116,6 +117,8 @@ def _stream_chat(
             model=model,
             temperature=temperature,
         )
+    except openai.APIError:
+        raise  # already logged with API context in azure_client.py
     except Exception:
-        logger.exception("Error while streaming Azure OpenAI response")
+        logger.exception("Unexpected error while streaming response")
         raise

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -118,7 +118,7 @@ def _stream_chat(
             temperature=temperature,
         )
     except openai.APIError:
-        raise  # already logged with API context in azure_client.py
+        raise  # all openai.APIError subtypes are logged in azure_client.py
     except Exception:
         logger.exception("Unexpected error while streaming response")
         raise

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "fastapi[standard]>=0.136.1",
-    "loguru>=0.7.2",
+    "loguru>=0.7.3",
     "openai>=2.33.0",
     "pydantic-settings>=2.14.0",
 ]
@@ -14,14 +14,14 @@ dependencies = [
 [dependency-groups]
 dev = [
     "add-trailing-comma>=4.0.0",
-    "coverage>=7.6.7",
-    "crosszip>=1.0.0",
-    "locust>=2.32.0",
-    "prek>=0.3.10",
-    "pytest-random-order>=1.1.1",
-    "pytest>=8.3.3",
-    "ruff>=0.15.11",
-    "ty>=0.0.32",
+    "coverage>=7.13.5",
+    "crosszip>=1.4.0",
+    "locust>=2.43.4",
+    "prek>=0.3.11",
+    "pytest-random-order>=1.2.0",
+    "pytest>=9.0.3",
+    "ruff>=0.15.12",
+    "ty>=0.0.34",
     "typecoverage>=1.0.1",
 ]
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -74,6 +74,13 @@ exclude = [".venv", "build", "dist"]
 [tool.ty.environment]
 python-version = "3.14"
 
+[tool.coverage.run]
+branch = true
+source = ["app"]
+
+[tool.coverage.report]
+fail_under = 100
+
 [tool.pytest.ini_options]
 addopts = [
     "--strict-markers",

--- a/backend/tests/test_azure_client.py
+++ b/backend/tests/test_azure_client.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import openai
@@ -6,6 +6,9 @@ import pytest
 
 from app.azure_client import get_azure_openai_client, stream_azure_openai_response
 from app.entities import AssistantModel, AssistantTemperature
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Iterable, Iterator
 
 
 class MockAzureClient:
@@ -19,10 +22,10 @@ class MockAzureClient:
         class MockCompletions:
             def __init__(self) -> None:
                 self.create_calls: list[dict[str, Any]] = []
-                self.return_value: list[object] = []
+                self.return_value: Iterable[object] = []
                 self.side_effect: Exception | None = None
 
-            def create(self, **kwargs: object) -> list[object]:
+            def create(self, **kwargs: object) -> Iterable[object]:
                 self.create_calls.append(kwargs)
                 if self.side_effect is not None:
                     raise self.side_effect
@@ -185,6 +188,31 @@ def test_get_azure_openai_client_wires_settings_correctly(
     assert captured["api_key"] == "test-key-123"
     assert captured["api_version"] == "2024-02-01"
     assert captured["max_retries"] == 5
+
+
+def test_openai_api_error_mid_stream_is_reraised(
+    mock_azure_client: MockAzureClient,
+) -> None:
+    mid_stream_exc: openai.InternalServerError = openai.InternalServerError(
+        "mid-stream failure",
+        response=_make_response(500),
+        body=None,
+    )
+
+    def failing_stream() -> Iterator[object]:
+        yield create_chunk("partial")
+        raise mid_stream_exc
+
+    mock_azure_client.chat.completions.return_value = failing_stream()
+
+    with pytest.raises(openai.InternalServerError, match="mid-stream failure"):
+        list(
+            stream_azure_openai_response(
+                messages=[{"role": "user", "content": "Test"}],
+                model=AssistantModel.FULL,
+                temperature=AssistantTemperature.BALANCED,
+            ),
+        )
 
 
 def test_stream_skips_chunks_with_empty_choices(

--- a/backend/tests/test_azure_client.py
+++ b/backend/tests/test_azure_client.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import httpx
+import openai
 import pytest
 
 from app.azure_client import get_azure_openai_client, stream_azure_openai_response
@@ -98,6 +100,54 @@ def test_api_exception(
     mock_azure_client.chat.completions.side_effect = exc_class(message)
 
     with pytest.raises(exc_class, match=message):
+        list(
+            stream_azure_openai_response(
+                messages=[{"role": "user", "content": "Test prompt"}],
+                model=AssistantModel.FULL,
+                temperature=AssistantTemperature.BALANCED,
+            ),
+        )
+
+
+def _make_request() -> httpx.Request:
+    return httpx.Request("POST", "https://example.openai.azure.com/")
+
+
+def _make_response(status_code: int) -> httpx.Response:
+    return httpx.Response(status_code=status_code, request=_make_request())
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        openai.AuthenticationError(
+            "auth failed",
+            response=_make_response(401),
+            body=None,
+        ),
+        openai.RateLimitError(
+            "rate limited",
+            response=_make_response(429),
+            body=None,
+        ),
+        openai.APIConnectionError(
+            message="connection failed",
+            request=_make_request(),
+        ),
+        openai.InternalServerError(
+            "server error",
+            response=_make_response(500),
+            body=None,
+        ),
+    ],
+)
+def test_openai_api_exceptions_are_reraised(
+    mock_azure_client: MockAzureClient,
+    exc: openai.APIError,
+) -> None:
+    mock_azure_client.chat.completions.side_effect = exc
+
+    with pytest.raises(type(exc)):
         list(
             stream_azure_openai_response(
                 messages=[{"role": "user", "content": "Test prompt"}],

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+import httpx
+import openai
 import pytest
 from fastapi.testclient import TestClient
 
@@ -97,12 +99,13 @@ def test_health() -> None:
 
 def test_ui_message_text_returns_content_field() -> None:
     message: UIMessage = UIMessage(
-        role=OpenAIMessageRole.USER, content="Hello from content"
+        role=OpenAIMessageRole.USER,
+        content="Hello from content",
     )
     assert message.text == "Hello from content"
 
 
-def test_stream_chat_reraises_exception(
+def test_stream_chat_reraises_non_openai_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def mock_stream(**kwargs: object) -> None:
@@ -113,6 +116,61 @@ def test_stream_chat_reraises_exception(
 
     client: TestClient = TestClient(app, raise_server_exceptions=True)
     with pytest.raises(RuntimeError, match="Upstream failure"):
+        client.post(
+            "/api/v1/chat",
+            json={
+                "messages": [
+                    {"role": "user", "parts": [{"type": "text", "text": "Hi"}]},
+                ],
+            },
+        )
+
+
+def _make_openai_request() -> httpx.Request:
+    return httpx.Request("POST", "https://example.openai.azure.com/")
+
+
+def _make_openai_response(status_code: int) -> httpx.Response:
+    return httpx.Response(status_code=status_code, request=_make_openai_request())
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        openai.RateLimitError(
+            "rate limit",
+            response=_make_openai_response(429),
+            body=None,
+        ),
+        openai.AuthenticationError(
+            "auth failed",
+            response=_make_openai_response(401),
+            body=None,
+        ),
+        openai.APIConnectionError(
+            message="connection failed",
+            request=_make_openai_request(),
+        ),
+        openai.InternalServerError(
+            "server error",
+            response=_make_openai_response(500),
+            body=None,
+        ),
+    ],
+)
+def test_stream_chat_reraises_openai_api_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    exc: openai.APIError,
+) -> None:
+    captured_exc: openai.APIError = exc
+
+    def mock_stream(**kwargs: object) -> None:
+        raise captured_exc
+
+    monkeypatch.setattr("app.main.stream_azure_openai_response", mock_stream)
+
+    client: TestClient = TestClient(app, raise_server_exceptions=True)
+    with pytest.raises(type(captured_exc)):
         client.post(
             "/api/v1/chat",
             json={

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1798,7 +1798,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.136.1" },
-    { name = "loguru", specifier = ">=0.7.2" },
+    { name = "loguru", specifier = ">=0.7.3" },
     { name = "openai", specifier = ">=2.33.0" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
 ]
@@ -1806,14 +1806,14 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "add-trailing-comma", specifier = ">=4.0.0" },
-    { name = "coverage", specifier = ">=7.6.7" },
-    { name = "crosszip", specifier = ">=1.0.0" },
-    { name = "locust", specifier = ">=2.32.0" },
-    { name = "prek", specifier = ">=0.3.10" },
-    { name = "pytest", specifier = ">=8.3.3" },
-    { name = "pytest-random-order", specifier = ">=1.1.1" },
-    { name = "ruff", specifier = ">=0.15.11" },
-    { name = "ty", specifier = ">=0.0.32" },
+    { name = "coverage", specifier = ">=7.13.5" },
+    { name = "crosszip", specifier = ">=1.4.0" },
+    { name = "locust", specifier = ">=2.43.4" },
+    { name = "prek", specifier = ">=0.3.11" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-random-order", specifier = ">=1.2.0" },
+    { name = "ruff", specifier = ">=0.15.12" },
+    { name = "ty", specifier = ">=0.0.34" },
     { name = "typecoverage", specifier = ">=1.0.1" },
 ]
 
@@ -1891,26 +1891,26 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.33"
+version = "0.0.34"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/44/9478c50c266826c1bf30d1692e589755bffa8f1c0a3eb7af8a346c255991/ty-0.0.33.tar.gz", hash = "sha256:46d63bda07403322cb6c28ccfdd5536be916e13df725c29f7ccd0a21f06bd9e8", size = 5559373, upload-time = "2026-04-28T10:45:13.18Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/69/e24eefe2c35c0fdbdec9b60e162727af669bb76d64d993d982eb67b24c38/ty-0.0.34.tar.gz", hash = "sha256:a6efe66b0f13c03a65e6c72ec9abfe2792e2fd063c74fa67e2c4930e29d661be", size = 5585933, upload-time = "2026-05-01T23:06:46.388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/24/e287388c63a19191be26b32ff4dbd06029834068150ebe2532939bc4c851/ty-0.0.33-py3-none-linux_armv6l.whl", hash = "sha256:94d0a9d2234261a8911396d59e506b5923fe0971dbda43b9dcea287936887fcc", size = 11021308, upload-time = "2026-04-28T10:45:43.34Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ca/ba1eed819895bd239fba8ee35dfcd5fcb266c203b0914a17a59579096bb5/ty-0.0.33-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4a2b5ba078f90de342f56b5f7979bb77c9b9b1d8625a041352ffc6ee93c4073", size = 10777272, upload-time = "2026-04-28T10:45:32.905Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a8/c3131d37b44b3fea1d6654a1c929a0cd0873822f77a90482b8ec28f6fbbd/ty-0.0.33-py3-none-macosx_11_0_arm64.whl", hash = "sha256:84ff5707825e9af9668d2bcf66975f93e520a63b524ab494e3a8265735be2563", size = 10201078, upload-time = "2026-04-28T10:45:23.374Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/db/d8e37ff0045810cc65e1ff36aa0da0a2253c05659787ac987df8a16c7897/ty-0.0.33-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e375285736f57886868e7af0b11c7b0ec5b6543fa15e7ad2a714fed9f077d4e0", size = 10732347, upload-time = "2026-04-28T10:45:21.444Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/1a/20e83a412506a918e4684fc67b567cf7cc13b105470b3428cb23c3d5aa13/ty-0.0.33-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5680f6350c3b4e46b8bff6d7bb132366ea239463d6cad4892725d06046e65464", size = 10808238, upload-time = "2026-04-28T10:45:38.565Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/4b/d0a39f4464dc6cb4cc2c159473ce216bd1846bfb684c0323a3cb36dce5c6/ty-0.0.33-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5535538bad8d0f7e62bcdff02197cdb30e41451d80b35d27e17d128f2e1dc5d", size = 11288348, upload-time = "2026-04-28T10:45:08.419Z" },
-    { url = "https://files.pythonhosted.org/packages/35/7e/f1745e0f9583363d7a83d9a4990fc244f76ecc30840ddad83dc16a33c52d/ty-0.0.33-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:da196c42bbbc069e1e21e3e52107c061aa9660352dae57a41930690b56e2c02d", size = 11789907, upload-time = "2026-04-28T10:45:19.064Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/71/25f39f46a12d662859d45bc648555d0661044eb43db6b5648c9947487da9/ty-0.0.33-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9281672921ef6d4460e03146b5e6c18cb1a3e3a3b8a1a88f6f33226d05a469b7", size = 11500774, upload-time = "2026-04-28T10:45:48.012Z" },
-    { url = "https://files.pythonhosted.org/packages/94/ec/136959ecbb7c71cb90537f5aea441c73f4ab24612868a6ecdc9d7444d32d/ty-0.0.33-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82c1b8f303f82da64e878108e764be3ecbcd7c9903ac0a7f7031614ed00b97ab", size = 11360314, upload-time = "2026-04-28T10:45:05.402Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/95/32809575c222f00beed498cb728e9290a0f5009f930025381bb7253b2206/ty-0.0.33-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:efe3af412c9ff67bce5fa37d0a2b0d8555c24072b145a5bac6c79637f1c83abe", size = 10707785, upload-time = "2026-04-28T10:45:10.836Z" },
-    { url = "https://files.pythonhosted.org/packages/13/89/c8e9531f7aa4a093359e15fa32c8e1277fbbe90d16894d7c6032d29f4b34/ty-0.0.33-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aeec29c91ea768601747da546c3efc20b72c2fb1bd52bcc786a5c6eeff51d27b", size = 10834987, upload-time = "2026-04-28T10:45:40.738Z" },
-    { url = "https://files.pythonhosted.org/packages/31/16/9835fbcf5338af1a1917bd28fdb8a7193c210b83f243aa286fa9f79cb3ad/ty-0.0.33-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a535977c52bbb5f7e96b8b70a6ad375ad077f4a9ff2492508ea3816a2b403819", size = 10968968, upload-time = "2026-04-28T10:45:30.26Z" },
-    { url = "https://files.pythonhosted.org/packages/36/69/64c76aabc1bc70c7f24b686cd93c3407f8ea430905e395f59bf9603ef571/ty-0.0.33-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1d732facf39fcb221ba279d469c5040d37883e964f123b1563888efd34818180", size = 11458077, upload-time = "2026-04-28T10:45:45.971Z" },
-    { url = "https://files.pythonhosted.org/packages/91/84/fae27b0c4718776a298690d31ca4cc1995f2e3e1c63a7b59e84c41498e9a/ty-0.0.33-py3-none-win32.whl", hash = "sha256:d90960b574428dc252f85e8598ec5fcb7f619794196b2fc95a90da075ed4681c", size = 10345364, upload-time = "2026-04-28T10:45:16.836Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a0/a2938b23ae3e1a09a2d7c189e2ac5f7113676bae4e0e23948b568e18e5f8/ty-0.0.33-py3-none-win_amd64.whl", hash = "sha256:c1c3aec62c44de610c6e95f0a4e97ac3dbc07934bfdbf1fd90d758c9ff72f48e", size = 11342470, upload-time = "2026-04-28T10:45:26.455Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/62/7fb948aace38d2f6329261bb33c035a8484549c74f1db28649c7a4c6fed9/ty-0.0.33-py3-none-win_arm64.whl", hash = "sha256:0d44f99ba1b441e55e2aa301b2ac0a21112784931b46a5f66f4ea9efe5620d97", size = 10742673, upload-time = "2026-04-28T10:45:35.555Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7b/8b85003d6639ef17a97dcbb31f4511cfe78f1c81a964470db100c8c883e7/ty-0.0.34-py3-none-linux_armv6l.whl", hash = "sha256:9ecc3d14f07a95a6ceb88e07f8e62358dbd37325d3d5bd56da7217ff1fef7fb8", size = 11067094, upload-time = "2026-05-01T23:06:21.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/25/b0098f65b020b015c40567c763fc66fffbec88b2ba6f584bca1e92f05ebb/ty-0.0.34-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0dccffd8a9d02321cd2dee3249df205e26d62694e741f4eeca36b157fd8b419f", size = 10840909, upload-time = "2026-05-01T23:06:18.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/55/5e4adcf7d2a1006b844903b27cb81244a9b748d850433a46a6c21776c401/ty-0.0.34-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b0ea47a2998e167ab3b21d2f4b5309a9cf33c297809f6d7e3e753252223174d0", size = 10279378, upload-time = "2026-05-01T23:06:37.962Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/f537dca0db8fe2558e8ab04d8941d687b384fcc1df5eb9023b2db75ac26c/ty-0.0.34-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b37da00b41a118a459ae56d8947e70651073fb33ebfbceb820e4a10b22d5023", size = 10817423, upload-time = "2026-05-01T23:06:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c4/55a3ad1da2815af1009bdc1b8c90dc11a364cd314e4b48c5128ba9d38859/ty-0.0.34-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81cbbb93c2342fe3de43e625d3a9eb149633e9f485e816ebf6395d08685355d8", size = 10851826, upload-time = "2026-05-01T23:06:24.198Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/9c7606af22d73fb43ea4369472d9c66ece11231be73b0efe8e3c61655559/ty-0.0.34-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c5b4dea1594a021289e172582df9cde7089dce14b276fc650e7b212b1772e12", size = 11356318, upload-time = "2026-05-01T23:06:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/20/54/bb423f663721ab4138b216425c6b55eaefd3a068243b24d6d8fe988f4e13/ty-0.0.34-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:030fb00aa2d2a5b5ae9d9183d574e0c82dae80566700a7490c43669d8ece40cd", size = 11902968, upload-time = "2026-05-01T23:06:35.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/22/01122b21ab6b534a2f618c6bbe5f1f7f49fd56f4b2ec8887cd6d40d08fb3/ty-0.0.34-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ae9555e24e36c63a8218e037a5a63f15579eb6aa94f41017e57cd41d335cfb5", size = 11548860, upload-time = "2026-05-01T23:06:42.155Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/86008b1392ec64bed1957bbcc7aaa43b466b50dfc91bb131841c21d7c5c3/ty-0.0.34-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99eb23df9ed129fc26d1ab00d6f0b8dfe5253b09c2ac6abdb11523fa70d67f10", size = 11457097, upload-time = "2026-05-01T23:06:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/92/3e/4558b2296963ba99c58d8409c57d7db4f3061b656c3613cb21c02c1ef4c2/ty-0.0.34-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:85de45382016eceae69e104815eb2cfa200787df104002e262a86cbd43ed2c02", size = 10798192, upload-time = "2026-05-01T23:06:40.004Z" },
+    { url = "https://files.pythonhosted.org/packages/76/bf/650d24402be2ef678528d60caac1d9477a40fc37e3792ecef07834fd7a4a/ty-0.0.34-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:14cb575fb8fa5131f5129d100cfe23c1575d23faf5dfc5158432749a3e38c9b5", size = 10890390, upload-time = "2026-05-01T23:06:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ef/ccd2ca13906079f7935fd7e067661b24233017f57d987d51d6a121d85bb5/ty-0.0.34-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c6fc0b69d8450e6910ba9db34572b959b81329a97ae273c391f70e9fb6c1aade", size = 11031564, upload-time = "2026-05-01T23:06:55.812Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2d/d27b72005b6f43599e3bcabab0d7135ac0c230b7a307bb99f9eea02c1cda/ty-0.0.34-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:30dfcec2f0fde3993f4f912ed0e057dcbebc8615299f610a4c2ddb7b5a3e1e06", size = 11553430, upload-time = "2026-05-01T23:06:31.096Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/12/20812e1ad930b8d4af70eebf19ad23cff6e31efcfa613ef884531fcdbaa1/ty-0.0.34-py3-none-win32.whl", hash = "sha256:97b77ddf007271b812a313a8f0a14929bc5590958433e1fb83ef585676f53342", size = 10436048, upload-time = "2026-05-01T23:06:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/afa095c5987868fbda27c0f731146ac8e3d07b357adfa83daccaee5b1a16/ty-0.0.34-py3-none-win_amd64.whl", hash = "sha256:1f543968accb952705134028d1fda8656882787dbbc667ad4d6c3ba23791d604", size = 11462526, upload-time = "2026-05-01T23:06:28.514Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8f/bf041a06260d77662c0605e56dacfe90b786bf824cbe1aed238d15fe5e84/ty-0.0.34-py3-none-win_arm64.whl", hash = "sha256:ea09108cbcb16b6b06d7596312b433bf49681e78d30e4dc7fb3c1b248a95e09a", size = 10846945, upload-time = "2026-05-01T23:06:44.428Z" },
 ]
 
 [[package]]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,34 @@
+coverage:
+  precision: 2
+  round: down
+  range: "90...100"
+
+  status:
+    project:
+      backend:
+        target: 100%
+        flags:
+          - backend
+      frontend:
+        target: 90%
+        flags:
+          - frontend
+    patch:
+      default:
+        target: 100%
+        threshold: 0%
+
+flags:
+  backend:
+    paths:
+      - backend/app/
+    carryforward: false
+  frontend:
+    paths:
+      - frontend/
+    carryforward: false
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false

--- a/frontend/.fallowrc.json
+++ b/frontend/.fallowrc.json
@@ -3,8 +3,10 @@
   "entry": ["src/main.tsx", "scripts/css-quality.mjs"],
   "ignorePatterns": ["**/*.css"],
   "ignoreDependencies": [
+    "@ai-sdk/__mocks__",
     "@emotion/react",
-    "@emotion/styled"
+    "@emotion/styled",
+    "@mui/__mocks__"
   ],
   "rules": {
     "unused-files": "error",

--- a/frontend/app/chat/page.test.tsx
+++ b/frontend/app/chat/page.test.tsx
@@ -123,7 +123,7 @@ function setupChat(
     messages: TestMessage[];
     status: string;
     error: Error | undefined;
-  }> = {}
+  }> = {},
 ) {
   mockUseChat.mockReturnValue({
     messages: INITIAL_MESSAGES,
@@ -195,7 +195,7 @@ describe("Home page", () => {
     render(<Home />);
     expect(screen.getByLabelText("Regenerate response")).toHaveAttribute(
       "aria-disabled",
-      "true"
+      "true",
     );
   });
 
@@ -220,7 +220,7 @@ describe("Home page", () => {
     fireEvent.click(screen.getByTestId("chat-input-send"));
     expect(mockSendMessage).toHaveBeenCalledWith(
       { text: "test message" },
-      { body: { model: "gpt-4o", temperature: "BALANCED" } }
+      { body: { model: "gpt-4o", temperature: "BALANCED" } },
     );
   });
 
@@ -231,7 +231,7 @@ describe("Home page", () => {
     fireEvent.click(screen.getByTestId("chat-input-send"));
     expect(mockSendMessage).toHaveBeenCalledWith(
       { text: "test message" },
-      { body: { model: "gpt-4o-mini", temperature: "BALANCED" } }
+      { body: { model: "gpt-4o-mini", temperature: "BALANCED" } },
     );
   });
 
@@ -242,7 +242,7 @@ describe("Home page", () => {
     fireEvent.click(screen.getByTestId("chat-input-send"));
     expect(mockSendMessage).toHaveBeenCalledWith(
       { text: "test message" },
-      { body: { model: "gpt-4o", temperature: "CREATIVE" } }
+      { body: { model: "gpt-4o", temperature: "CREATIVE" } },
     );
   });
 

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -196,13 +196,13 @@ function ControlPanel({
 export default function Home() {
   const [model, setModel] = useState<AssistantModel>(AssistantModel.FULL);
   const [temperature, setTemperature] = useState<AssistantTemperature>(
-    AssistantTemperature.BALANCED
+    AssistantTemperature.BALANCED,
   );
   const [darkMode, setDarkMode] = useState(true);
 
   const transport = useMemo(
     () => new TextStreamChatTransport({ api: CHAT_API_URL }),
-    []
+    [],
   );
   const { messages, sendMessage, regenerate, error, status } = useChat({
     messages: INITIAL_MESSAGES,
@@ -214,7 +214,7 @@ export default function Home() {
 
   const theme = useMemo(
     () => createTheme({ palette: { mode: darkMode ? "dark" : "light" } }),
-    [darkMode]
+    [darkMode],
   );
 
   const handleSendMessage = async (message: string) => {

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -77,7 +77,7 @@
     "formatter": {
       "jsxQuoteStyle": "double",
       "quoteProperties": "asNeeded",
-      "trailingCommas": "es5",
+      "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
       "bracketSameLine": false,

--- a/frontend/client/types/assistant.test.ts
+++ b/frontend/client/types/assistant.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe("assistantModelSchema", () => {
   test.each(
-    Object.values(AssistantModel)
+    Object.values(AssistantModel),
   )("accepts valid model %s", (model) => {
     expect(assistantModelSchema.parse(model)).toBe(model);
   });
@@ -24,7 +24,7 @@ describe("assistantModelSchema", () => {
 
 describe("assistantTemperatureSchema", () => {
   test.each(
-    Object.values(AssistantTemperature)
+    Object.values(AssistantTemperature),
   )("accepts valid temperature %s", (temperature) => {
     expect(assistantTemperatureSchema.parse(temperature)).toBe(temperature);
   });

--- a/frontend/components/messages/AssistantMessage.test.tsx
+++ b/frontend/components/messages/AssistantMessage.test.tsx
@@ -65,7 +65,7 @@ describe("AssistantMessage", () => {
         content={content}
         isFirstMessage={false}
       />,
-      { wrapper: Wrapper }
+      { wrapper: Wrapper },
     );
     expect(screen.getByTestId("markdown-content")).toBeInTheDocument();
   });
@@ -76,7 +76,7 @@ describe("AssistantMessage", () => {
         content={'```javascript\nconsole.log("hello");\n```'}
         isFirstMessage={false}
       />,
-      { wrapper: Wrapper }
+      { wrapper: Wrapper },
     );
     expect(screen.getByTestId("markdown-content")).toBeInTheDocument();
     expect(screen.getByTestId("code-block")).toBeInTheDocument();
@@ -95,7 +95,7 @@ describe("AssistantMessage", () => {
         content={content}
         isFirstMessage={isFirstMessage}
       />,
-      { wrapper: Wrapper }
+      { wrapper: Wrapper },
     );
     expect(container).toMatchSnapshot();
   });
@@ -106,7 +106,7 @@ describe("AssistantMessage", () => {
         content="Welcome!"
         isFirstMessage={true}
       />,
-      { wrapper: Wrapper }
+      { wrapper: Wrapper },
     );
     expect(queryByRole("button")).not.toBeInTheDocument();
   });
@@ -117,7 +117,7 @@ describe("AssistantMessage", () => {
         content="A response"
         isFirstMessage={false}
       />,
-      { wrapper: Wrapper }
+      { wrapper: Wrapper },
     );
     expect(getByRole("button")).toBeInTheDocument();
   });
@@ -150,7 +150,7 @@ describe("AssistantMessage", () => {
           content="Copy me!"
           isFirstMessage={false}
         />,
-        { wrapper: Wrapper }
+        { wrapper: Wrapper },
       );
 
       fireEvent.click(getByRole("button"));

--- a/frontend/components/messages/AssistantMessage.tsx
+++ b/frontend/components/messages/AssistantMessage.tsx
@@ -126,7 +126,7 @@ const AssistantMessage: React.FC<AssistantMessageProps> = ({
         );
       },
     }),
-    [colors]
+    [colors],
   );
 
   return (

--- a/frontend/components/messages/ChatInput.test.tsx
+++ b/frontend/components/messages/ChatInput.test.tsx
@@ -7,7 +7,7 @@ describe("ChatInput component", () => {
   it("should render the ChatInput component and match the snapshot", () => {
     const onSendMessageMock = vi.fn();
     const { asFragment } = render(
-      <ChatInput onSendMessage={onSendMessageMock} />
+      <ChatInput onSendMessage={onSendMessageMock} />,
     );
 
     expect(asFragment()).toMatchSnapshot();
@@ -16,7 +16,7 @@ describe("ChatInput component", () => {
   test("should call onSendMessage with the message when Enter is pressed", () => {
     const onSendMessageMock = vi.fn();
     const { getByPlaceholderText } = render(
-      <ChatInput onSendMessage={onSendMessageMock} />
+      <ChatInput onSendMessage={onSendMessageMock} />,
     );
 
     const input = getByPlaceholderText("Type your message...");
@@ -29,7 +29,7 @@ describe("ChatInput component", () => {
   test("should not call onSendMessage if Enter is pressed with an empty message", () => {
     const onSendMessageMock = vi.fn();
     const { getByPlaceholderText } = render(
-      <ChatInput onSendMessage={onSendMessageMock} />
+      <ChatInput onSendMessage={onSendMessageMock} />,
     );
 
     const input = getByPlaceholderText("Type your message...");
@@ -41,7 +41,7 @@ describe("ChatInput component", () => {
   test("should not send when Shift+Enter is pressed", () => {
     const onSendMessageMock = vi.fn();
     const { getByPlaceholderText } = render(
-      <ChatInput onSendMessage={onSendMessageMock} />
+      <ChatInput onSendMessage={onSendMessageMock} />,
     );
 
     const input = getByPlaceholderText("Type your message...");
@@ -59,7 +59,7 @@ describe("ChatInput component", () => {
   test("should send message when send button is clicked", () => {
     const onSendMessageMock = vi.fn();
     const { getByPlaceholderText, getByLabelText } = render(
-      <ChatInput onSendMessage={onSendMessageMock} />
+      <ChatInput onSendMessage={onSendMessageMock} />,
     );
 
     fireEvent.change(getByPlaceholderText("Type your message..."), {
@@ -73,7 +73,7 @@ describe("ChatInput component", () => {
   test("send button is disabled when message is empty", () => {
     const onSendMessageMock = vi.fn();
     const { getByLabelText } = render(
-      <ChatInput onSendMessage={onSendMessageMock} />
+      <ChatInput onSendMessage={onSendMessageMock} />,
     );
 
     expect(getByLabelText("Send message")).toBeDisabled();
@@ -85,7 +85,7 @@ describe("ChatInput component", () => {
       <ChatInput
         onSendMessage={onSendMessageMock}
         disabled={true}
-      />
+      />,
     );
 
     expect(getByLabelText("Send message")).toBeDisabled();

--- a/frontend/components/parameters/DropdownParameter.test.tsx
+++ b/frontend/components/parameters/DropdownParameter.test.tsx
@@ -18,7 +18,7 @@ describe("DropdownParameter", () => {
         tooltipTitle="Select option"
         ariaLabel="Select an option"
         options={OPTIONS}
-      />
+      />,
     );
     expect(screen.getByLabelText("Select an option")).toBeInTheDocument();
   });
@@ -32,7 +32,7 @@ describe("DropdownParameter", () => {
         tooltipTitle="Select"
         ariaLabel="Select an option"
         options={OPTIONS}
-      />
+      />,
     );
     expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
   });
@@ -46,7 +46,7 @@ describe("DropdownParameter", () => {
         tooltipTitle="Select"
         ariaLabel="Select an option"
         options={OPTIONS}
-      />
+      />,
     );
     fireEvent.click(screen.getByLabelText("Select an option"));
     expect(screen.getByText("Option 1")).toBeInTheDocument();
@@ -64,7 +64,7 @@ describe("DropdownParameter", () => {
         tooltipTitle="Select"
         ariaLabel="Select an option"
         options={OPTIONS}
-      />
+      />,
     );
     fireEvent.click(screen.getByLabelText("Select an option"));
     fireEvent.click(screen.getByText("Option 2"));

--- a/frontend/e2e-tests/chat-page.spec.ts
+++ b/frontend/e2e-tests/chat-page.spec.ts
@@ -37,7 +37,7 @@ test.describe("Chat Page Model and Temperature Combinations", () => {
 
     // Verify the initial assistant message is present
     await expect(
-      page.getByText("Hi, I am a chat bot. How can I help you today?")
+      page.getByText("Hi, I am a chat bot. How can I help you today?"),
     ).toBeVisible();
 
     // Set the model and temperature (using selectors or any UI interaction method you have)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.0.3",
+  "packageManager": "pnpm@11.0.4",
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 3000",
     "build": "rm -rf dist && vite build",
@@ -19,17 +19,17 @@
     "type-coverage": "type-coverage --strict --at-least 100"
   },
   "dependencies": {
-    "@ai-sdk/react": "^3.0.174",
+    "@ai-sdk/react": "^3.0.176",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
-    "ai": "^6.0.172",
+    "ai": "^6.0.174",
     "lucide-react": "^1.14.0",
-    "react": "^19",
-    "react-dom": "^19",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "react-markdown": "^10.1.0",
-    "zod": "^4.4.1"
+    "zod": "^4.4.2"
   },
   "browserList": {
     "production": [
@@ -44,26 +44,26 @@
     ]
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.13",
+    "@biomejs/biome": "2.4.14",
     "@playwright/test": "^1.59.1",
     "@projectwallace/css-code-quality": "^3.1.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "^25",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
+    "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@types/react-gtm-module": "^2.0.4",
     "@typescript-eslint/parser": "^8.59.1",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.5",
-    "eslint": "^10.2.1",
+    "eslint": "^10.3.0",
     "eslint-plugin-no-unsanitized": "^4.1.5",
     "eslint-plugin-react": "^7.37.5",
-    "fallow": "^2.57.0",
-    "globals": "^17.5.0",
+    "fallow": "^2.62.0",
+    "globals": "^17.6.0",
     "jsdom": "^29.1.1",
     "type-coverage": "^2.29.7",
-    "typescript": "^6",
+    "typescript": "^6.0.3",
     "vite": "^8.0.10",
     "vitest": "^4.1.5"
   }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@ai-sdk/react':
-        specifier: ^3.0.174
-        version: 3.0.174(react@19.2.5)(zod@4.4.1)
+        specifier: ^3.0.176
+        version: 3.0.176(react@19.2.5)(zod@4.4.2)
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.14)(react@19.2.5)
@@ -24,27 +24,27 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ai:
-        specifier: ^6.0.172
-        version: 6.0.172(zod@4.4.1)
+        specifier: ^6.0.174
+        version: 6.0.174(zod@4.4.2)
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.5)
       react:
-        specifier: ^19
+        specifier: ^19.2.5
         version: 19.2.5
       react-dom:
-        specifier: ^19
+        specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
       zod:
-        specifier: ^4.4.1
-        version: 4.4.1
+        specifier: ^4.4.2
+        version: 4.4.2
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.4.13
-        version: 2.4.13
+        specifier: 2.4.14
+        version: 2.4.14
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
@@ -58,20 +58,20 @@ importers:
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/node':
-        specifier: ^25
+        specifier: ^25.6.0
         version: 25.6.0
       '@types/react':
-        specifier: ^19
+        specifier: ^19.2.14
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       '@types/react-gtm-module':
         specifier: ^2.0.4
         version: 2.0.4
       '@typescript-eslint/parser':
         specifier: ^8.59.1
-        version: 8.59.1(eslint@10.2.1)(typescript@6.0.3)
+        version: 8.59.1(eslint@10.3.0)(typescript@6.0.3)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.10(@types/node@25.6.0))
@@ -79,20 +79,20 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
       eslint:
-        specifier: ^10.2.1
-        version: 10.2.1
+        specifier: ^10.3.0
+        version: 10.3.0
       eslint-plugin-no-unsanitized:
         specifier: ^4.1.5
-        version: 4.1.5(eslint@10.2.1)
+        version: 4.1.5(eslint@10.3.0)
       eslint-plugin-react:
         specifier: ^7.37.5
-        version: 7.37.5(eslint@10.2.1)
+        version: 7.37.5(eslint@10.3.0)
       fallow:
-        specifier: ^2.57.0
-        version: 2.57.0
+        specifier: ^2.62.0
+        version: 2.62.0
       globals:
-        specifier: ^17.5.0
-        version: 17.5.0
+        specifier: ^17.6.0
+        version: 17.6.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -100,7 +100,7 @@ importers:
         specifier: ^2.29.7
         version: 2.29.7(typescript@6.0.3)
       typescript:
-        specifier: ^6
+        specifier: ^6.0.3
         version: 6.0.3
       vite:
         specifier: ^8.0.10
@@ -114,14 +114,14 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ai-sdk/gateway@3.0.107':
-    resolution: {integrity: sha512-JwODLcuTe8rWXJwQcNPE5fiadjCOKHxNGtL5pHqEhFQSuWs6x47oVRkLs/Zw6eUhTsuXiZbyJ3QJHVIyLKX5hg==}
+  '@ai-sdk/gateway@3.0.109':
+    resolution: {integrity: sha512-r6dOqThjODp1vOhGRJg2OCmyB/ZOQtGx1esZ2SDvwDX5XoX8dBqYaYjLg8MPXTzMGJSgOkJyCxWgUcZtAl16pw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.25':
-    resolution: {integrity: sha512-yjGPZPiJm79ZOYk0anXn2LkVqUFgStZqEOdyoynhkaAg+yOCuv6PJwf+1gUW0eSIUnYEboT2TPbPX/bxZpx4gw==}
+  '@ai-sdk/provider-utils@4.0.26':
+    resolution: {integrity: sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -130,8 +130,8 @@ packages:
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/react@3.0.174':
-    resolution: {integrity: sha512-fMtfM1EM4Ev0uU35ehDWf2IG8Dlq8Ax9w8H9nlZgk5dxRi7ktYUE7+czaXZJVc/GaAUSiB1VHV/HAJleKfQ4OQ==}
+  '@ai-sdk/react@3.0.176':
+    resolution: {integrity: sha512-8CKMdSJDAHHUYEJSsI+HGanP/75dOYtnLWQ5WtQMvdmsA4PUVy8Hv6Bn1npoZBcTh250ESsuSptvctxFuIJrYw==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
@@ -175,8 +175,8 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -200,59 +200,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.4.13':
-    resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
+  '@biomejs/biome@2.4.14':
+    resolution: {integrity: sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.13':
-    resolution: {integrity: sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==}
+  '@biomejs/cli-darwin-arm64@2.4.14':
+    resolution: {integrity: sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.13':
-    resolution: {integrity: sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==}
+  '@biomejs/cli-darwin-x64@2.4.14':
+    resolution: {integrity: sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.13':
-    resolution: {integrity: sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==}
+  '@biomejs/cli-linux-arm64-musl@2.4.14':
+    resolution: {integrity: sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.13':
-    resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
+  '@biomejs/cli-linux-arm64@2.4.14':
+    resolution: {integrity: sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.13':
-    resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
+  '@biomejs/cli-linux-x64-musl@2.4.14':
+    resolution: {integrity: sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.13':
-    resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
+  '@biomejs/cli-linux-x64@2.4.14':
+    resolution: {integrity: sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.13':
-    resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
+  '@biomejs/cli-win32-arm64@2.4.14':
+    resolution: {integrity: sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.13':
-    resolution: {integrity: sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==}
+  '@biomejs/cli-win32-x64@2.4.14':
+    resolution: {integrity: sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -399,43 +399,43 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@fallow-cli/darwin-arm64@2.57.0':
-    resolution: {integrity: sha512-6WXWJZsO63tuJ4Va32+UYxNjDSem2yc+1bmIzKaVH24aXGfZtaxPx+jl0mnqKeZjgeAy5WiW37BRXqc0MUK+LA==}
+  '@fallow-cli/darwin-arm64@2.62.0':
+    resolution: {integrity: sha512-ygV7NiH8rJcgfUEVB8nrPeDHZC2lSofNvU8mEXGj3th+krGiJKkfTnZ7LZojhHHB5hRd6OtDQ2gKkcmjnPkKYg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@fallow-cli/darwin-x64@2.57.0':
-    resolution: {integrity: sha512-sXcRsPHBGxexcqJMRBVm/KZN/lbPNjLzZuy176CXhyac35K3dddYYtsPw3wAWIaWD7BQWKkPUG/We9/qr++Hgw==}
+  '@fallow-cli/darwin-x64@2.62.0':
+    resolution: {integrity: sha512-RIHE4uYDATIfIpLDN8ftV5div29b6N72UEXousRrdbatMGe5OBbWYub/uSVMqvaS1PoVIQjQhQom9x0l5qwvAw==}
     cpu: [x64]
     os: [darwin]
 
-  '@fallow-cli/linux-arm64-gnu@2.57.0':
-    resolution: {integrity: sha512-1EaIIoweDbKqEpOu3d3e8p62tdsCyMq2SywaGCBQmy34EUrqEfQTBJQy8GDogA3iVfOGFxPTgGan+/0xkOIgpw==}
+  '@fallow-cli/linux-arm64-gnu@2.62.0':
+    resolution: {integrity: sha512-WxtwG2DaoT2x6Xmdf/lBGAnpr7E0G5tNb9HB21waGmGhcXqO5Hg8f8vk9SGpu2ziQTgyNgpG45XNtCOZ85Qedw==}
     cpu: [arm64]
     os: [linux]
 
-  '@fallow-cli/linux-arm64-musl@2.57.0':
-    resolution: {integrity: sha512-A2IMY37urRxVoAy6iIfdLLL0tWcJBweI6Ed/j3IhLqBNgW3h73aqSNIeCPPGvvNFJ1ysMjBuhr9KtXBOzVIrbg==}
+  '@fallow-cli/linux-arm64-musl@2.62.0':
+    resolution: {integrity: sha512-5OsPYLk1r8iPoibcxExEv0k0D/1bBRYiSV6W/MRYEfW20dYBQTL2MksuWL12ZZohgjBYQjf2j06+UR/ZD112oQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@fallow-cli/linux-x64-gnu@2.57.0':
-    resolution: {integrity: sha512-OqTRYtGDcwOFHkhrFEE4clA55Jmk85XhBSpUTu+kfNPvz6SwPmkcQD8rWiI7RmRaBVEwkDXp5V6rD6ZpKtuPtw==}
+  '@fallow-cli/linux-x64-gnu@2.62.0':
+    resolution: {integrity: sha512-r66pI7h5oeYTT0rf5dsANYvu5kHo9ycbFbZEnEujdB+KtzvxelBrlU+b+GuC/J4ALzTL1b5y9ntLkgPt9pxmJw==}
     cpu: [x64]
     os: [linux]
 
-  '@fallow-cli/linux-x64-musl@2.57.0':
-    resolution: {integrity: sha512-2Odhbk7mJy0AFgLSODLHp8Dznx4xiyS7QFZX0Q/YXGovWnG0hn9zLv5fMv/gvdJ9T7BXnbc7bj8OumWB3OrZBg==}
+  '@fallow-cli/linux-x64-musl@2.62.0':
+    resolution: {integrity: sha512-rUfXfldWHOepwPuCB3w+WPOxJu6wpXM5H8n4PVDkeTPeiDUsa+mi69pt1hgvnTM3E4LuXgjdHhIyXn9db3tQmg==}
     cpu: [x64]
     os: [linux]
 
-  '@fallow-cli/win32-arm64-msvc@2.57.0':
-    resolution: {integrity: sha512-H9wDNWNiCHayxz4wPB4T6a3sG0OrND9jt2Upx74hNMtZCZE4M9Zea6179od2sgH8aeY5S4QXNxwKSdSRh2Y0Ug==}
+  '@fallow-cli/win32-arm64-msvc@2.62.0':
+    resolution: {integrity: sha512-CnMQiBrOtxnP90h8dOAhQW57D0hkbe0RehMaJQ7qwxjFe3fXsQLbcnRM+5Bhd+aj1nDAbN90+1hJ6H/n82CuSA==}
     cpu: [arm64]
     os: [win32]
 
-  '@fallow-cli/win32-x64-msvc@2.57.0':
-    resolution: {integrity: sha512-uEUoycw3c6TRmbr8m5kMY3jp67gZXx2jkDAGprN4iNyuNUBEvYQjOBc58LPuUuCKWd0V69sUvQ2Bo/G7Azw4xQ==}
+  '@fallow-cli/win32-x64-msvc@2.62.0':
+    resolution: {integrity: sha512-mKtEB6P5I+t238ynTgGy6pzJGzeYOolXRMhh8+/tDX78vWNpDiHOlLxsIqkE6ojihuXrq7f3sGq9t7ElbJ4miQ==}
     cpu: [x64]
     os: [win32]
 
@@ -906,8 +906,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ai@6.0.172:
-    resolution: {integrity: sha512-o12q2SDlrN4btPU2FkFSVEeZiKfQuSbDFixXH8I7AE/zuCXMbN9ilaPThdoAc8mS9+QnhUGy8cSP0IgT3Q+p0A==}
+  ai@6.0.174:
+    resolution: {integrity: sha512-bTrfLUWHWtkjzWyCY4bmyuk4Qvmj4S4NSNsXyNSVVqkmftQNtxRj7dzUoMeQDBBwlJO6fC7m2Q/lNOPqQQfAGA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1224,8 +1224,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.2.1:
-    resolution: {integrity: sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==}
+  eslint@10.3.0:
+    resolution: {integrity: sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1271,8 +1271,8 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  fallow@2.57.0:
-    resolution: {integrity: sha512-gur3LU5/rWkcfUQN9HRYy1Dad1erg7SV/cbXyti47c+IUaF4NSj5lmwbpuFyTlNUPZ8X7OMmzh7BJpxLYkoCbA==}
+  fallow@2.62.0:
+    resolution: {integrity: sha512-jNSBDIyUcjb3mSH8TH/Dmx4NNy910DJihOfdOJCLxSPsPBEnWtkFl6YkkmgDLj1OLMohzWjiUfDMlOnElQY85A==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -1371,8 +1371,8 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  globals@17.5.0:
-    resolution: {integrity: sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==}
+  globals@17.6.0:
+    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -1872,8 +1872,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1992,8 +1992,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.12:
-    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2518,8 +2518,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod@4.4.1:
-    resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
+  zod@4.4.2:
+    resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -2528,28 +2528,28 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/gateway@3.0.107(zod@4.4.1)':
+  '@ai-sdk/gateway@3.0.109(zod@4.4.2)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.25(zod@4.4.1)
+      '@ai-sdk/provider-utils': 4.0.26(zod@4.4.2)
       '@vercel/oidc': 3.2.0
-      zod: 4.4.1
+      zod: 4.4.2
 
-  '@ai-sdk/provider-utils@4.0.25(zod@4.4.1)':
+  '@ai-sdk/provider-utils@4.0.26(zod@4.4.2)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.8
-      zod: 4.4.1
+      zod: 4.4.2
 
   '@ai-sdk/provider@3.0.10':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.174(react@19.2.5)(zod@4.4.1)':
+  '@ai-sdk/react@3.0.176(react@19.2.5)(zod@4.4.2)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.25(zod@4.4.1)
-      ai: 6.0.172(zod@4.4.1)
+      '@ai-sdk/provider-utils': 4.0.26(zod@4.4.2)
+      ai: 6.0.174(zod@4.4.2)
       react: 19.2.5
       swr: 2.4.1(react@19.2.5)
       throttleit: 2.1.0
@@ -2584,7 +2584,7 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -2603,7 +2603,7 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/parser@7.29.2':
+  '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
 
@@ -2612,7 +2612,7 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
   '@babel/traverse@7.29.0':
@@ -2620,7 +2620,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       debug: 4.4.3
@@ -2634,39 +2634,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@2.4.13':
+  '@biomejs/biome@2.4.14':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.13
-      '@biomejs/cli-darwin-x64': 2.4.13
-      '@biomejs/cli-linux-arm64': 2.4.13
-      '@biomejs/cli-linux-arm64-musl': 2.4.13
-      '@biomejs/cli-linux-x64': 2.4.13
-      '@biomejs/cli-linux-x64-musl': 2.4.13
-      '@biomejs/cli-win32-arm64': 2.4.13
-      '@biomejs/cli-win32-x64': 2.4.13
+      '@biomejs/cli-darwin-arm64': 2.4.14
+      '@biomejs/cli-darwin-x64': 2.4.14
+      '@biomejs/cli-linux-arm64': 2.4.14
+      '@biomejs/cli-linux-arm64-musl': 2.4.14
+      '@biomejs/cli-linux-x64': 2.4.14
+      '@biomejs/cli-linux-x64-musl': 2.4.14
+      '@biomejs/cli-win32-arm64': 2.4.14
+      '@biomejs/cli-win32-x64': 2.4.14
 
-  '@biomejs/cli-darwin-arm64@2.4.13':
+  '@biomejs/cli-darwin-arm64@2.4.14':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.13':
+  '@biomejs/cli-darwin-x64@2.4.14':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.13':
+  '@biomejs/cli-linux-arm64-musl@2.4.14':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.13':
+  '@biomejs/cli-linux-arm64@2.4.14':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.13':
+  '@biomejs/cli-linux-x64-musl@2.4.14':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.13':
+  '@biomejs/cli-linux-x64@2.4.14':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.13':
+  '@biomejs/cli-win32-arm64@2.4.14':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.13':
+  '@biomejs/cli-win32-x64@2.4.14':
     optional: true
 
   '@bramus/specificity@2.4.2':
@@ -2796,9 +2796,9 @@ snapshots:
 
   '@emotion/weak-memoize@0.4.0': {}
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.3.0)':
     dependencies:
-      eslint: 10.2.1
+      eslint: 10.3.0
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -2828,28 +2828,28 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@fallow-cli/darwin-arm64@2.57.0':
+  '@fallow-cli/darwin-arm64@2.62.0':
     optional: true
 
-  '@fallow-cli/darwin-x64@2.57.0':
+  '@fallow-cli/darwin-x64@2.62.0':
     optional: true
 
-  '@fallow-cli/linux-arm64-gnu@2.57.0':
+  '@fallow-cli/linux-arm64-gnu@2.62.0':
     optional: true
 
-  '@fallow-cli/linux-arm64-musl@2.57.0':
+  '@fallow-cli/linux-arm64-musl@2.62.0':
     optional: true
 
-  '@fallow-cli/linux-x64-gnu@2.57.0':
+  '@fallow-cli/linux-x64-gnu@2.62.0':
     optional: true
 
-  '@fallow-cli/linux-x64-musl@2.57.0':
+  '@fallow-cli/linux-x64-musl@2.62.0':
     optional: true
 
-  '@fallow-cli/win32-arm64-msvc@2.57.0':
+  '@fallow-cli/win32-arm64-msvc@2.62.0':
     optional: true
 
-  '@fallow-cli/win32-x64-msvc@2.57.0':
+  '@fallow-cli/win32-x64-msvc@2.62.0':
     optional: true
 
   '@humanfs/core@0.19.2':
@@ -3157,14 +3157,14 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/parser@8.59.1(eslint@10.2.1)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.59.1(eslint@10.3.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.1
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3
-      eslint: 10.2.1
+      eslint: 10.3.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -3279,13 +3279,13 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  ai@6.0.172(zod@4.4.1):
+  ai@6.0.174(zod@4.4.2):
     dependencies:
-      '@ai-sdk/gateway': 3.0.107(zod@4.4.1)
+      '@ai-sdk/gateway': 3.0.109(zod@4.4.2)
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.25(zod@4.4.1)
+      '@ai-sdk/provider-utils': 4.0.26(zod@4.4.2)
       '@opentelemetry/api': 1.9.0
-      zod: 4.4.1
+      zod: 4.4.2
 
   ajv@6.15.0:
     dependencies:
@@ -3670,11 +3670,11 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-no-unsanitized@4.1.5(eslint@10.2.1):
+  eslint-plugin-no-unsanitized@4.1.5(eslint@10.3.0):
     dependencies:
-      eslint: 10.2.1
+      eslint: 10.3.0
 
-  eslint-plugin-react@7.37.5(eslint@10.2.1):
+  eslint-plugin-react@7.37.5(eslint@10.3.0):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -3682,7 +3682,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.2
-      eslint: 10.2.1
+      eslint: 10.3.0
       estraverse: 5.3.0
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
@@ -3707,9 +3707,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.2.1:
+  eslint@10.3.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.5.5
@@ -3772,18 +3772,18 @@ snapshots:
 
   extend@3.0.2: {}
 
-  fallow@2.57.0:
+  fallow@2.62.0:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      '@fallow-cli/darwin-arm64': 2.57.0
-      '@fallow-cli/darwin-x64': 2.57.0
-      '@fallow-cli/linux-arm64-gnu': 2.57.0
-      '@fallow-cli/linux-arm64-musl': 2.57.0
-      '@fallow-cli/linux-x64-gnu': 2.57.0
-      '@fallow-cli/linux-x64-musl': 2.57.0
-      '@fallow-cli/win32-arm64-msvc': 2.57.0
-      '@fallow-cli/win32-x64-msvc': 2.57.0
+      '@fallow-cli/darwin-arm64': 2.62.0
+      '@fallow-cli/darwin-x64': 2.62.0
+      '@fallow-cli/linux-arm64-gnu': 2.62.0
+      '@fallow-cli/linux-arm64-musl': 2.62.0
+      '@fallow-cli/linux-x64-gnu': 2.62.0
+      '@fallow-cli/linux-x64-musl': 2.62.0
+      '@fallow-cli/win32-arm64-msvc': 2.62.0
+      '@fallow-cli/win32-x64-msvc': 2.62.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -3886,7 +3886,7 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  globals@17.5.0: {}
+  globals@17.6.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -4258,7 +4258,7 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
@@ -4513,7 +4513,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
 
@@ -4638,9 +4638,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.12:
+  postcss@8.5.13:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5142,7 +5142,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.12
+      postcss: 8.5.13
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -5255,6 +5255,6 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod@4.4.1: {}
+  zod@4.4.2: {}
 
   zwitch@2.0.4: {}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -19,5 +19,5 @@ if (!root) {
 createRoot(root).render(
   <React.StrictMode>
     <ChatPage />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reportsDirectory: "coverage",
-      reporter: ["text", "html"],
+      reporter: ["text", "html", "lcov"],
       thresholds: {
         statements: 90,
         branches: 75,
@@ -51,6 +51,7 @@ export default defineConfig({
     environment: "jsdom",
     exclude: ["**/node_modules/**", "**/dist/**", "**/e2e-tests/**"],
     globals: true,
+    pool: "threads",
     setupFiles: ["./vitest.setup.ts"],
   },
 });

--- a/makefiles/backend.mk
+++ b/makefiles/backend.mk
@@ -2,7 +2,7 @@ BACKEND_DIR=./backend
 
 # Backend tool commands
 PYTEST=uv run pytest app tests --verbose
-PYCOVERAGE=uv run coverage run -m pytest app tests && uv run coverage report --fail-under=95 && uv run coverage html
+PYCOVERAGE=uv run coverage run -m pytest app tests && uv run coverage report && uv run coverage html && uv run coverage xml
 PYTYPECOVERAGE=uv run python -m typecoverage app tests locustfile.py --recursive --exit-nonzero-on-issues
 FASTAPI_RUNSERVER=uv run fastapi dev app/main.py --host 0.0.0.0 --port 8000
 OPENAPI_SCHEMA=uv run python -c "from app.main import app; app.openapi()"


### PR DESCRIPTION
## Summary

- **`azure_client.py`**: Extract `_create_openai_stream` helper that wraps `client.chat.completions.create()` with specific `openai.*` exception catches — auth failures log as `ERROR`, rate limits and connection errors as `WARNING`, other HTTP errors as `ERROR` with the status code. The streaming loop in `stream_azure_openai_response` now also catches `openai.APIError` mid-stream with `logger.exception` and character count for context.
- **`main.py`**: Replace the broad `except Exception` in `_stream_chat` with two targeted handlers: `except openai.APIError` (re-raises silently, already logged upstream) and `except Exception` (logs unexpected non-openai errors). Note: raising `HTTPException` inside a `StreamingResponse` generator is not feasible — Starlette raises `RuntimeError("Caught handled exception, but response already started.")` because 200 OK headers are committed before the generator is iterated.
- **Tests**: Add parametrized coverage for `AuthenticationError`, `RateLimitError`, `APIConnectionError`, and `InternalServerError` in both `test_azure_client.py` and `test_main.py`.

## Test plan

- [x] All 25 backend tests pass
- [x] Full `make qa` passes (format, lint, type-check, coverage ≥ 95%, type coverage 100%)
- [x] No new ruff violations (complexity thresholds satisfied by the helper extraction)