### PR TITLE
ci: run e2e tests in CI and fix server cleanup

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -101,9 +101,6 @@ jobs:
         run: pnpm dlx @lhci/cli@0.15.1 upload
         continue-on-error: true
 
-      #- name: Run end-to-end tests
-      #  run: make e2e-test
-
       - name: Upload coverage reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,3 +87,42 @@ jobs:
         with:
           name: frontend-coverage
           path: frontend/coverage
+
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d  # v6.0.5
+        with:
+          version: 11.0.3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version-file: "frontend/.nvmrc"
+          cache: "pnpm"
+          cache-dependency-path: "frontend/pnpm-lock.yaml"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make
+
+      - name: Install frontend dependencies
+        working-directory: ./frontend
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec playwright install --with-deps
+
+      - name: Run e2e tests
+        run: make e2e-test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: playwright-report
+          path: frontend/playwright-report

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,8 @@ docker-down:
 	@echo "$(COLOR_BLUE_BG)Stopping containerized services...$(COLOR_RESET)"
 	docker-compose down
 
-# End-to-end testing (starts both servers, waits, then runs tests)
-e2e-test: run-backend run-frontend
-	@sleep 10
+# End-to-end testing (Playwright manages the frontend dev server via webServer config)
+e2e-test:
 	$(MAKE) frontend-e2e-test
 
 .PHONY: lint format type-check test type-coverage clean \

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -70,10 +70,9 @@ export default defineConfig({
     //},
   ],
 
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: "pnpm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+  },
 });


### PR DESCRIPTION
## Summary

- Adds a new `e2e` job to `tests.yml` so Playwright integration tests run in CI **in parallel** with the existing `backend` and `frontend` unit-test jobs (closes #6)
- Enables Playwright's `webServer` option in `playwright.config.ts` — the Vite dev server is started before tests and torn down automatically afterwards, fixing the leftover-process issue described in the issue comment
- Simplifies the `e2e-test` Makefile target: the manual `run-backend run-frontend` prerequisites and `sleep 10` are removed since Playwright handles the server lifecycle
- Removes the stale commented-out e2e step from `qa.yml`

## Test plan

- [ ] Verify the `e2e` CI job appears alongside `backend` and `frontend` in the Actions run for this PR
- [ ] Confirm the Playwright report artifact is uploaded on success and failure
- [ ] Locally: `make e2e-test` should start the dev server, run tests, and exit cleanly with no orphaned processes