### PR TITLE
Improve QA workflow log hygiene

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -6,12 +6,18 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   qa:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
@@ -98,7 +104,9 @@ jobs:
 
       - name: Lighthouse CI (upload)
         working-directory: ./frontend
-        run: pnpm dlx @lhci/cli@0.15.1 upload
+        run: pnpm dlx @lhci/cli@0.15.1 upload --githubToken="$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: true
 
       - name: Upload coverage reports

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -107,7 +107,6 @@ jobs:
         run: pnpm dlx @lhci/cli@0.15.1 upload --githubToken="$GITHUB_TOKEN"
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        continue-on-error: true
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,5 +1,6 @@
 import globals from "globals";
 import noUnsanitized from "eslint-plugin-no-unsanitized";
+import reactDom from "eslint-plugin-react-dom";
 import tsParser from "@typescript-eslint/parser";
 
 /**
@@ -34,13 +35,27 @@ export default [
     },
     plugins: {
       "no-unsanitized": noUnsanitized,
+      "react-dom": reactDom,
     },
     rules: {
-      // Prevent XSS via React's dangerouslySetInnerHTML escape hatch
+      // Prevent XSS via React DOM escape hatches and dangerous URL patterns
+      "react-dom/no-dangerously-set-innerhtml": "error",
+      "react-dom/no-dangerously-set-innerhtml-with-children": "error",
+      "react-dom/no-script-url": "error",
+      "react-dom/no-unsafe-iframe-sandbox": "error",
+      "react-dom/no-unsafe-target-blank": "error",
+
+      // Catch dangerouslySetInnerHTML keys hidden inside spread props
       "no-restricted-syntax": [
         "error",
         {
-          selector: "JSXAttribute[name.name='dangerouslySetInnerHTML']",
+          selector:
+            "ObjectExpression > Property[key.name='dangerouslySetInnerHTML']",
+          message: "Do not create React dangerouslySetInnerHTML props.",
+        },
+        {
+          selector:
+            "ObjectExpression > Property[key.value='dangerouslySetInnerHTML']",
           message: "Do not use React dangerouslySetInnerHTML.",
         },
       ],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^10.3.0",
     "eslint-plugin-no-unsanitized": "^4.1.5",
+    "eslint-plugin-react-dom": "^5.7.1",
     "fallow": "^2.62.0",
     "globals": "^17.6.0",
     "jsdom": "^29.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       eslint-plugin-no-unsanitized:
         specifier: ^4.1.5
         version: 4.1.5(eslint@10.3.0)
+      eslint-plugin-react-dom:
+        specifier: ^5.7.1
+        version: 5.7.1(eslint@10.3.0)(typescript@5.9.3)
       fallow:
         specifier: ^2.62.0
         version: 2.62.0
@@ -363,6 +366,41 @@ packages:
   '@eslint-community/regexpp@4.12.2':
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint-react/ast@5.7.1':
+    resolution: {integrity: sha512-1j6jWWzwIrD61gEVb+llxp7hIW6mua6Mi0S5IrHlWhvbfM3mnQStfPgqddf4+FJbFXXQZyIR13ecZewSA/6ADw==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      eslint: ^10.2.1
+      typescript: '*'
+
+  '@eslint-react/eslint@5.7.1':
+    resolution: {integrity: sha512-Gc3GfXTBBXYTSkkBa41XyXj5dK7v4VWdkT60xIgRS+0PogxA6X1JNl+oGZgSIH5lxdLUnRYSYlTy+NDbs9dFPw==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      eslint: ^10.2.1
+      typescript: '*'
+
+  '@eslint-react/jsx@5.7.1':
+    resolution: {integrity: sha512-IxgVUuWTT2LdzkcXqmrewE4rkyiHom/8MqaW1HqhjamO6GfXXtouJdO2VIQ57w7xekbUG+bFEpJiGgSpTi+O3Q==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      eslint: ^10.2.1
+      typescript: '*'
+
+  '@eslint-react/shared@5.7.1':
+    resolution: {integrity: sha512-rdG2EWDtXB4jt8XgIByoWCUFeiPcimNBurhZuaOIEMpITfBoNaMtcr9cesZvrWvRcn8ElWri1jFIBQ5HydCxmQ==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      eslint: ^10.2.1
+      typescript: '*'
+
+  '@eslint-react/var@5.7.1':
+    resolution: {integrity: sha512-ZkgBgHa2v28iXVBeYnZ5g1WlZOsak06QLvfueiATzX53PkRye0//I8tZ5/rStb+IUFX7kTbXX0i8fh7jG7a3Jw==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      eslint: ^10.2.1
+      typescript: '*'
 
   '@eslint/config-array@0.23.5':
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
@@ -828,6 +866,13 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.59.1':
+    resolution: {integrity: sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.59.1':
     resolution: {integrity: sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -998,6 +1043,9 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
@@ -1086,6 +1134,13 @@ packages:
     resolution: {integrity: sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg==}
     peerDependencies:
       eslint: ^9 || ^10
+
+  eslint-plugin-react-dom@5.7.1:
+    resolution: {integrity: sha512-JUhW+jl/VyUw7fipXZHGG3AVZDNVG3lAXoewjKBaR6va/fnR8gG6iQY+R0boTF2f37C06vyPpnld9SOW2TV/8A==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      eslint: ^10.2.1
+      typescript: '*'
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -1796,6 +1851,9 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  string-ts@2.3.1:
+    resolution: {integrity: sha512-xSJq+BS52SaFFAVxuStmx6n5aYZU571uYUnUrPXkPFCfdHyZMMlbP2v2Wx5sNBnAVzq/2+0+mcBLBa3Xa5ubYw==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -1877,6 +1935,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-pattern@5.9.0:
+    resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -2361,6 +2422,63 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.2': {}
 
+  '@eslint-react/ast@5.7.1(eslint@10.3.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@10.3.0)(typescript@5.9.3)
+      eslint: 10.3.0
+      string-ts: 2.3.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint-react/eslint@5.7.1(eslint@10.3.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/utils': 8.59.1(eslint@10.3.0)(typescript@5.9.3)
+      eslint: 10.3.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint-react/jsx@5.7.1(eslint@10.3.0)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-react/ast': 5.7.1(eslint@10.3.0)(typescript@5.9.3)
+      '@eslint-react/eslint': 5.7.1(eslint@10.3.0)(typescript@5.9.3)
+      '@eslint-react/shared': 5.7.1(eslint@10.3.0)(typescript@5.9.3)
+      '@eslint-react/var': 5.7.1(eslint@10.3.0)(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/utils': 8.59.1(eslint@10.3.0)(typescript@5.9.3)
+      eslint: 10.3.0
+      ts-pattern: 5.9.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint-react/shared@5.7.1(eslint@10.3.0)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-react/eslint': 5.7.1(eslint@10.3.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@10.3.0)(typescript@5.9.3)
+      eslint: 10.3.0
+      ts-pattern: 5.9.0
+      typescript: 5.9.3
+      zod: 4.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint-react/var@5.7.1(eslint@10.3.0)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-react/ast': 5.7.1(eslint@10.3.0)(typescript@5.9.3)
+      '@eslint-react/eslint': 5.7.1(eslint@10.3.0)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.1
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/utils': 8.59.1(eslint@10.3.0)(typescript@5.9.3)
+      eslint: 10.3.0
+      ts-pattern: 5.9.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
@@ -2762,6 +2880,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.59.1(eslint@10.3.0)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0)
+      '@typescript-eslint/scope-manager': 8.59.1
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
+      eslint: 10.3.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.59.1':
     dependencies:
       '@typescript-eslint/types': 8.59.1
@@ -2925,6 +3054,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  compare-versions@6.1.1: {}
+
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
@@ -3003,6 +3134,20 @@ snapshots:
   eslint-plugin-no-unsanitized@4.1.5(eslint@10.3.0):
     dependencies:
       eslint: 10.3.0
+
+  eslint-plugin-react-dom@5.7.1(eslint@10.3.0)(typescript@5.9.3):
+    dependencies:
+      '@eslint-react/ast': 5.7.1(eslint@10.3.0)(typescript@5.9.3)
+      '@eslint-react/eslint': 5.7.1(eslint@10.3.0)(typescript@5.9.3)
+      '@eslint-react/jsx': 5.7.1(eslint@10.3.0)(typescript@5.9.3)
+      '@eslint-react/shared': 5.7.1(eslint@10.3.0)(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/utils': 8.59.1(eslint@10.3.0)(typescript@5.9.3)
+      compare-versions: 6.1.1
+      eslint: 10.3.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-scope@9.1.2:
     dependencies:
@@ -3855,6 +4000,8 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  string-ts@2.3.1: {}
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -3926,6 +4073,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-pattern@5.9.0: {}
 
   tslib@1.14.1: {}
 


### PR DESCRIPTION
## Summary
- fetch full Git history in the QA workflow so fallow hotspot analysis is complete
- pass the GitHub token to Lighthouse CI upload and grant the workflow scoped status-write permission
- make Lighthouse CI upload a required QA step by removing continue-on-error
- harden frontend security linting for React DOM antipatterns, including spread-prop dangerouslySetInnerHTML bypasses

## CI log review
Inspected all GitHub Actions runs for commit 67dfbe3924b5ece3059c26e4babad7b076a97a19:
- Docker Build Checks: success; only benign Debian xz/update-alternatives output while building the backend image
- QA Checks: success; actionable shallow-clone warning from fallow and Lighthouse upload skipped GitHub status creation because no token was provided
- prek: success; no actionable warnings
- Unit Tests: success; Codecov GPG trust output and setup-node cache reservation races are upstream/tooling noise, not repo validation failures

## Review feedback addressed
- Follow-up for https://github.com/IndrajeetPatil/chatgpt-clone/pull/62#discussion_r3178093815: object-literal dangerouslySetInnerHTML keys are now blocked so spread props and string-literal keys cannot bypass the guardrail.

## Validation
- make qa
- pnpm run lint:security
- pnpm install --frozen-lockfile
- uv tool run --from prek==0.3.11 prek run check-yaml --files .github/workflows/qa.yml
- git diff --check
- synthetic ESLint probes confirmed detection for direct dangerouslySetInnerHTML, spread-prop dangerouslySetInnerHTML, string-literal dangerouslySetInnerHTML keys, javascript: URLs, unsafe target=_blank links, and unsafe iframe sandbox values