### PR TITLE
fix: align chat UI with Vercel interface guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ The UI is built with [Material
 UI](https://mui.com/material-ui/getting-started/) components and follows
 Google's Material Design.
 
+Frontend interface work uses Vercel's [Web Interface
+Guidelines](https://vercel.com/design/guidelines) as the review baseline for
+new and changed UI. Treat those guidelines as the target for interaction
+details such as keyboard operability, visible focus states, loading and error
+states, reduced-motion support, resilient layout, semantic controls, and
+concise action copy.
+
 ## Setup
 
 - Clone the repository
@@ -74,6 +81,12 @@ To validate Lighthouse scores against thresholds locally:
 ``` bash
 make lighthouse
 ```
+
+Lighthouse covers automated performance, accessibility, best-practices, and
+SEO checks. New UI changes should still be reviewed against the Vercel Web
+Interface Guidelines, because many interaction, content, and layout details
+require manual judgment. The guidelines are an implementation target, not a
+blanket claim that every existing screen is already fully compliant.
 
 To remove all build artifacts and tool caches for a clean slate (useful
 for testing cold-cache behaviour):

--- a/frontend/app/chat/page.test.tsx
+++ b/frontend/app/chat/page.test.tsx
@@ -147,6 +147,20 @@ describe("Home page", () => {
     expect(msg).toHaveAttribute("data-first-message", "true");
   });
 
+  test("renders main landmark, page heading, and skip link", () => {
+    render(<Home />);
+    expect(screen.getByRole("main")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "Chatbot Template",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Skip to Message" }),
+    ).toHaveAttribute("href", "#message-input");
+  });
+
   test("renders user messages via renderMessage", () => {
     setupChat({
       messages: [
@@ -165,19 +179,21 @@ describe("Home page", () => {
   test("shows CircularProgress when status is submitted", () => {
     setupChat({ status: "submitted" });
     render(<Home />);
-    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Generating…");
   });
 
   test("shows CircularProgress when status is streaming", () => {
     setupChat({ status: "streaming" });
     render(<Home />);
-    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Generating…");
   });
 
   test("shows error Alert when error is present", () => {
     setupChat({ error: new Error("Network error") });
     render(<Home />);
-    expect(screen.getByText(/Network error/)).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Something went wrong. Try sending your message again. Details: Network error",
+    );
   });
 
   test("starts in dark mode (toggle shows Switch to light mode)", () => {
@@ -191,12 +207,9 @@ describe("Home page", () => {
     expect(screen.getByLabelText("Switch to dark mode")).toBeInTheDocument();
   });
 
-  test("regenerate button is aria-disabled when no user messages", () => {
+  test("regenerate button is disabled when no user messages", () => {
     render(<Home />);
-    expect(screen.getByLabelText("Regenerate response")).toHaveAttribute(
-      "aria-disabled",
-      "true",
-    );
+    expect(screen.getByLabelText("Regenerate response")).toBeDisabled();
   });
 
   test("regenerate invokes chat retry when there is a user message and not loading", () => {
@@ -211,6 +224,22 @@ describe("Home page", () => {
     render(<Home />);
     fireEvent.click(screen.getByLabelText("Regenerate response"));
     expect(mockRegenerate).not.toHaveBeenCalled();
+  });
+
+  test("syncs browser chrome metadata with the selected theme", () => {
+    const meta = document.createElement("meta");
+    meta.name = "theme-color";
+    document.head.append(meta);
+
+    render(<Home />);
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+    expect(meta.content).toBe("#121212");
+
+    fireEvent.click(screen.getByLabelText("Switch to light mode"));
+    expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(meta.content).toBe("#ffffff");
+
+    meta.remove();
   });
 
   test("sends message from the chat input", async () => {

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -15,10 +15,11 @@ import {
   IconButton,
   Stack,
   Tooltip,
+  Typography,
 } from "@mui/material";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { TextStreamChatTransport } from "ai";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { getModelDisplay, getTemperatureDisplay } from "@/client/helpers";
 import { AssistantModel, AssistantTemperature } from "@/client/types/assistant";
 import AssistantMessage from "@/components/messages/AssistantMessage";
@@ -38,6 +39,43 @@ const INITIAL_MESSAGES: UIMessage[] = [
     ],
   },
 ];
+
+const DARK_THEME_COLOR = "#121212";
+const LIGHT_THEME_COLOR = "#ffffff";
+
+const VISUALLY_HIDDEN_SX = {
+  border: 0,
+  clip: "rect(0 0 0 0)",
+  height: 1,
+  margin: -1,
+  overflow: "hidden",
+  padding: 0,
+  position: "absolute",
+  whiteSpace: "nowrap",
+  width: 1,
+} as const;
+
+const SKIP_LINK_SX = {
+  backgroundColor: "background.paper",
+  border: 1,
+  borderColor: "primary.main",
+  borderRadius: 1,
+  boxShadow: 2,
+  color: "primary.main",
+  left: 16,
+  px: 2,
+  py: 1,
+  position: "absolute",
+  top: 16,
+  transform: "translateY(-200%)",
+  zIndex: "tooltip",
+  "&:focus-visible": {
+    outline: "2px solid",
+    outlineColor: "primary.main",
+    outlineOffset: 2,
+    transform: "translateY(0)",
+  },
+} as const;
 
 const MODEL_OPTIONS = [
   { value: AssistantModel.FULL, label: "GPT-4o" },
@@ -84,11 +122,34 @@ function MessageList({
   error,
 }: MessageListProps) {
   return (
-    <Box sx={{ flexGrow: 1, overflowY: "auto", p: 2 }}>
+    <Box
+      component="section"
+      aria-label="Chat conversation"
+      sx={{ flexGrow: 1, overflowY: "auto", p: 2 }}
+    >
       <Stack spacing={2}>
         {messages.map(renderMessage)}
-        {assistantIsLoading && <CircularProgress />}
-        {error && <Alert severity="error">Error: {error.message}</Alert>}
+        {assistantIsLoading && (
+          <Stack
+            aria-live="polite"
+            direction="row"
+            role="status"
+            spacing={1}
+            sx={{ alignItems: "center" }}
+          >
+            <CircularProgress
+              aria-hidden={true}
+              size={20}
+            />
+            <Typography variant="body2">Generating…</Typography>
+          </Stack>
+        )}
+        {error && (
+          <Alert severity="error">
+            Something went wrong. Try sending your message again. Details:{" "}
+            {error.message}
+          </Alert>
+        )}
       </Stack>
     </Box>
   );
@@ -173,16 +234,15 @@ function ControlPanel({
           options={TEMPERATURE_OPTIONS}
         />
         <Tooltip title="Regenerate Response">
-          <IconButton
-            onClick={() => {
-              if (!disabled && canRegenerate) onRegenerate();
-            }}
-            aria-label="Regenerate response"
-            aria-disabled={disabled || !canRegenerate}
-            sx={{ opacity: disabled || !canRegenerate ? 0.38 : 1 }}
-          >
-            <RefreshIcon />
-          </IconButton>
+          <span>
+            <IconButton
+              disabled={disabled || !canRegenerate}
+              onClick={onRegenerate}
+              aria-label="Regenerate response"
+            >
+              <RefreshIcon />
+            </IconButton>
+          </span>
         </Tooltip>
         <DarkModeToggle
           darkMode={darkMode}
@@ -197,12 +257,23 @@ function ControlPanel({
   );
 }
 
+function syncBrowserTheme(darkMode: boolean) {
+  document.documentElement.style.colorScheme = darkMode ? "dark" : "light";
+  document
+    .querySelector<HTMLMetaElement>('meta[name="theme-color"]')
+    ?.setAttribute("content", darkMode ? DARK_THEME_COLOR : LIGHT_THEME_COLOR);
+}
+
 export default function Home() {
   const [model, setModel] = useState<AssistantModel>(AssistantModel.FULL);
   const [temperature, setTemperature] = useState<AssistantTemperature>(
     AssistantTemperature.BALANCED,
   );
   const [darkMode, setDarkMode] = useState(true);
+
+  useEffect(() => {
+    syncBrowserTheme(darkMode);
+  }, [darkMode]);
 
   const transport = useMemo(
     () => new TextStreamChatTransport({ api: CHAT_API_URL }),
@@ -234,10 +305,30 @@ export default function Home() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Container
-        maxWidth="md"
-        sx={{ height: "100vh", display: "flex", flexDirection: "column" }}
+      <Box
+        href="#message-input"
+        component="a"
+        sx={SKIP_LINK_SX}
       >
+        Skip to Message
+      </Box>
+      <Container
+        id="chat-main"
+        component="main"
+        maxWidth="md"
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100dvh",
+          minHeight: 0,
+        }}
+      >
+        <Typography
+          component="h1"
+          sx={VISUALLY_HIDDEN_SX}
+        >
+          Chatbot Template
+        </Typography>
         <MessageList
           messages={messages}
           assistantIsLoading={assistantIsLoading}

--- a/frontend/app/styles.css
+++ b/frontend/app/styles.css
@@ -13,6 +13,7 @@
 }
 
 :root {
+  color-scheme: dark;
   font-family:
     "Geist", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
@@ -25,6 +26,7 @@
 body {
   margin: 0;
   min-width: 320px;
+  touch-action: manipulation;
 }
 
 #root {

--- a/frontend/components/messages/ChatInput.test.tsx
+++ b/frontend/components/messages/ChatInput.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 
 import ChatInput from "./ChatInput";
@@ -13,81 +13,98 @@ describe("ChatInput component", () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test("should call onSendMessage with the message when Enter is pressed", () => {
+  test("should call onSendMessage with the message when Ctrl+Enter is pressed", () => {
     const onSendMessageMock = vi.fn();
-    const { getByPlaceholderText } = render(
-      <ChatInput onSendMessage={onSendMessageMock} />,
-    );
+    render(<ChatInput onSendMessage={onSendMessageMock} />);
 
-    const input = getByPlaceholderText("Type your message...");
+    const input = screen.getByLabelText("Message");
     fireEvent.change(input, { target: { value: "Hello, World!" } });
-    fireEvent.keyDown(input, { key: "Enter", code: "Enter", charCode: 13 });
-
-    expect(onSendMessageMock).toHaveBeenCalledWith("Hello, World!");
-  });
-
-  test("should not call onSendMessage if Enter is pressed with an empty message", () => {
-    const onSendMessageMock = vi.fn();
-    const { getByPlaceholderText } = render(
-      <ChatInput onSendMessage={onSendMessageMock} />,
-    );
-
-    const input = getByPlaceholderText("Type your message...");
-    fireEvent.keyDown(input, { key: "Enter", code: "Enter", charCode: 13 });
-
-    expect(onSendMessageMock).not.toHaveBeenCalled();
-  });
-
-  test("should not send when Shift+Enter is pressed", () => {
-    const onSendMessageMock = vi.fn();
-    const { getByPlaceholderText } = render(
-      <ChatInput onSendMessage={onSendMessageMock} />,
-    );
-
-    const input = getByPlaceholderText("Type your message...");
-    fireEvent.change(input, { target: { value: "Hello" } });
     fireEvent.keyDown(input, {
       key: "Enter",
       code: "Enter",
       charCode: 13,
-      shiftKey: true,
+      ctrlKey: true,
     });
+
+    expect(onSendMessageMock).toHaveBeenCalledWith("Hello, World!");
+  });
+
+  test("plain Enter does not send a multiline message", () => {
+    const onSendMessageMock = vi.fn();
+    render(<ChatInput onSendMessage={onSendMessageMock} />);
+
+    const input = screen.getByLabelText("Message");
+    fireEvent.change(input, { target: { value: "Hello" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter", charCode: 13 });
 
     expect(onSendMessageMock).not.toHaveBeenCalled();
   });
 
+  test("should not call onSendMessage if Ctrl+Enter is pressed with an empty message", () => {
+    const onSendMessageMock = vi.fn();
+    render(<ChatInput onSendMessage={onSendMessageMock} />);
+
+    const input = screen.getByLabelText("Message");
+    fireEvent.keyDown(input, {
+      key: "Enter",
+      code: "Enter",
+      charCode: 13,
+      ctrlKey: true,
+    });
+
+    expect(onSendMessageMock).not.toHaveBeenCalled();
+    expect(screen.getByText("Enter a message before sending.")).toBeVisible();
+  });
+
   test("should send message when send button is clicked", () => {
     const onSendMessageMock = vi.fn();
-    const { getByPlaceholderText, getByLabelText } = render(
-      <ChatInput onSendMessage={onSendMessageMock} />,
-    );
+    render(<ChatInput onSendMessage={onSendMessageMock} />);
 
-    fireEvent.change(getByPlaceholderText("Type your message..."), {
+    fireEvent.change(screen.getByLabelText("Message"), {
       target: { value: "Hello via button" },
     });
-    fireEvent.click(getByLabelText("Send message"));
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
 
     expect(onSendMessageMock).toHaveBeenCalledWith("Hello via button");
   });
 
-  test("send button is disabled when message is empty", () => {
+  test("send button stays enabled when message is empty and surfaces validation", () => {
     const onSendMessageMock = vi.fn();
-    const { getByLabelText } = render(
-      <ChatInput onSendMessage={onSendMessageMock} />,
-    );
+    render(<ChatInput onSendMessage={onSendMessageMock} />);
 
-    expect(getByLabelText("Send message")).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onSendMessageMock).not.toHaveBeenCalled();
+    expect(screen.getByText("Enter a message before sending.")).toBeVisible();
+  });
+
+  test("clears empty-submit validation when the user starts typing", () => {
+    const onSendMessageMock = vi.fn();
+    render(<ChatInput onSendMessage={onSendMessageMock} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(screen.getByText("Enter a message before sending.")).toBeVisible();
+
+    fireEvent.change(screen.getByLabelText("Message"), {
+      target: { value: "Hello" },
+    });
+
+    expect(
+      screen.getByText(
+        "Press Enter for a new line. Press Ctrl+Enter or Cmd+Enter to send.",
+      ),
+    ).toBeVisible();
   });
 
   test("send button is disabled when disabled prop is true", () => {
     const onSendMessageMock = vi.fn();
-    const { getByLabelText } = render(
+    render(
       <ChatInput
         onSendMessage={onSendMessageMock}
         disabled={true}
       />,
     );
 
-    expect(getByLabelText("Send message")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
   });
 });

--- a/frontend/components/messages/ChatInput.tsx
+++ b/frontend/components/messages/ChatInput.tsx
@@ -1,10 +1,10 @@
 import SendIcon from "@mui/icons-material/Send";
-import { Box, IconButton, TextField } from "@mui/material";
+import { Box, Button, CircularProgress, TextField } from "@mui/material";
 import type React from "react";
-import { type KeyboardEvent, useState } from "react";
+import { type KeyboardEvent, useRef, useState } from "react";
 
 interface ChatInputProps {
-  onSendMessage: (message: string) => void;
+  onSendMessage: (message: string) => void | Promise<void>;
   disabled?: boolean;
 }
 
@@ -12,24 +12,33 @@ const ChatInput: React.FC<ChatInputProps> = ({
   disabled = false,
   onSendMessage,
 }) => {
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const [message, setMessage] = useState("");
+  const [submittedEmpty, setSubmittedEmpty] = useState(false);
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    sendMessage();
+    void sendMessage();
   };
 
-  const sendMessage = () => {
-    if (message.trim()) {
-      onSendMessage(message.trim());
-      setMessage("");
+  const sendMessage = async () => {
+    const trimmedMessage = message.trim();
+
+    if (!trimmedMessage) {
+      setSubmittedEmpty(true);
+      inputRef.current?.focus();
+      return;
     }
+
+    setSubmittedEmpty(false);
+    setMessage("");
+    await onSendMessage(trimmedMessage);
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Enter" && !event.shiftKey) {
+    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();
-      sendMessage();
+      void sendMessage();
     }
   };
 
@@ -37,27 +46,57 @@ const ChatInput: React.FC<ChatInputProps> = ({
     <Box
       component="form"
       onSubmit={handleSubmit}
-      sx={{ display: "flex", alignItems: "flex-end", mt: 2 }}
+      sx={{
+        alignItems: "flex-start",
+        display: "flex",
+        gap: 1,
+        mt: 2,
+      }}
     >
       <TextField
+        id="message-input"
+        inputRef={inputRef}
         multiline={true}
         fullWidth={true}
         disabled={disabled}
-        placeholder="Type your message..."
+        label="Message"
+        name="message"
+        autoComplete="off"
+        placeholder="Type your message…"
         rows={2}
         value={message}
-        onChange={(e) => setMessage(e.target.value)}
+        onChange={(e) => {
+          setMessage(e.target.value);
+          if (submittedEmpty) setSubmittedEmpty(false);
+        }}
         onKeyDown={handleKeyDown}
-        sx={{ mr: 1 }}
+        error={submittedEmpty}
+        helperText={
+          submittedEmpty
+            ? "Enter a message before sending."
+            : "Press Enter for a new line. Press Ctrl+Enter or Cmd+Enter to send."
+        }
+        sx={{ flexGrow: 1 }}
       />
-      <IconButton
+      <Button
         type="submit"
-        color="primary"
-        disabled={disabled || !message.trim()}
-        aria-label="Send message"
+        variant="contained"
+        disabled={disabled}
+        endIcon={
+          disabled ? (
+            <CircularProgress
+              aria-hidden={true}
+              color="inherit"
+              size={16}
+            />
+          ) : (
+            <SendIcon />
+          )
+        }
+        sx={{ minHeight: 56, mt: 2, touchAction: "manipulation" }}
       >
-        <SendIcon />
-      </IconButton>
+        Send
+      </Button>
     </Box>
   );
 };

--- a/frontend/components/messages/__snapshots__/ChatInput.test.tsx.snap
+++ b/frontend/components/messages/__snapshots__/ChatInput.test.tsx.snap
@@ -3,19 +3,30 @@
 exports[`ChatInput component > should render the ChatInput component and match the snapshot 1`] = `
 <DocumentFragment>
   <form
-    class="MuiBox-root css-mkkhhh"
+    class="MuiBox-root css-gpjb9n"
   >
     <div
-      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-15e2bhn-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-11ot7ee-MuiFormControl-root-MuiTextField-root"
     >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
+        data-shrink="false"
+        for="message-input"
+        id="message-input-label"
+      >
+        Message
+      </label>
       <div
         class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-multiline css-zsp0bh-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <textarea
+          aria-describedby="message-input-helper-text"
           aria-invalid="false"
+          autocomplete="off"
           class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_0_"
-          placeholder="Type your message..."
+          id="message-input"
+          name="message"
+          placeholder="Type your message…"
           rows="2"
           style="height: 0px; overflow: hidden;"
         />
@@ -31,36 +42,42 @@ exports[`ChatInput component > should render the ChatInput component and match t
           class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-1nf2c5d-MuiNotchedOutlined-root"
+            class="css-1n64csd-MuiNotchedOutlined-root"
           >
-            <span
-              aria-hidden="true"
-              class="notranslate"
-            >
-              ​
+            <span>
+              Message
             </span>
           </legend>
         </fieldset>
       </div>
+      <p
+        class="MuiFormHelperText-root MuiFormHelperText-sizeMedium MuiFormHelperText-contained css-er619e-MuiFormHelperText-root"
+        id="message-input-helper-text"
+      >
+        Press Enter for a new line. Press Ctrl+Enter or Cmd+Enter to send.
+      </p>
     </div>
     <button
-      aria-label="Send message"
-      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorPrimary MuiIconButton-sizeMedium css-1svfwy9-MuiButtonBase-root-MuiIconButton-root"
-      disabled=""
-      tabindex="-1"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-sizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-sizeMedium MuiButton-colorPrimary css-17aun4j-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
       type="submit"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-        data-testid="SendIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
+      Send
+      <span
+        class="MuiButton-icon MuiButton-endIcon css-1gulhci-MuiButton-endIcon"
       >
-        <path
-          d="M2.01 21 23 12 2.01 3 2 10l15 2-15 2z"
-        />
-      </svg>
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          data-testid="SendIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M2.01 21 23 12 2.01 3 2 10l15 2-15 2z"
+          />
+        </svg>
+      </span>
     </button>
   </form>
 </DocumentFragment>

--- a/frontend/e2e-tests/chat-page.spec.ts
+++ b/frontend/e2e-tests/chat-page.spec.ts
@@ -56,11 +56,11 @@ test.describe("Chat Page Model and Temperature Combinations", () => {
         exact: true,
       })
       .click();
-    await page.getByPlaceholder("Type your message...").click();
+    await page.getByLabel("Message").click();
     // Send a user message
-    await page.getByPlaceholder("Type your message...").click();
-    await page.getByPlaceholder("Type your message...").fill("test message");
-    await page.locator("form").getByRole("button").click();
+    await page.getByLabel("Message").click();
+    await page.getByLabel("Message").fill("test message");
+    await page.locator("form").getByRole("button", { name: "Send" }).click();
 
     await expect(page.getByText(expectedResponse)).toBeVisible();
   });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,7 @@
       name="description"
       content="Built as a hobby full-stack project"
     />
+    <meta name="theme-color" content="#121212" />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />


### PR DESCRIPTION
## Summary
- document Vercel's Web Interface Guidelines as the review baseline and implementation target for new and changed frontend UI
- update the chat input with a real label, empty-submit validation, Ctrl/Cmd+Enter submission, Enter-newline behavior, and an in-flight Send loading indicator
- add accessible loading/error states, main/heading/skip-link structure, disabled inactive regenerate control, and browser theme-color/color-scheme syncing
- update unit snapshots and e2e selectors for the accessible Message field and Send button

## Validation
- make qa
- pnpm run test:e2e
- pnpm run build
- git diff --check