### PR TITLE
[codex] Add GPT-5.5 code quality review

### DIFF
--- a/code-quality-evals/gpt-55-review.md
+++ b/code-quality-evals/gpt-55-review.md
@@ -1,0 +1,230 @@
+# GPT-5.5 Code Quality Review
+
+Assessment date: 2026-05-04
+
+Scope: current `main` at `d28e12d`, reviewed by inspecting source,
+tests, tooling configuration, CI workflows, and lightweight line-count
+metrics. This is a code-quality review, not a penetration test, load test,
+or production-readiness certification.
+
+## Executive Summary
+
+The codebase is in strong shape for a full-stack chatbot template. It is
+small, readable, well-tooled, and guarded by unusually strict quality gates:
+100% backend line and branch coverage, frontend coverage floors, type coverage
+checks, dependency audits, security linting, Checkov, Lighthouse CI, Playwright,
+file naming checks, and commit-message validation.
+
+The main quality risks are not basic code hygiene problems. They are the
+expected gaps between a template and a production LLM application: no
+authentication or authorization, no rate limiting, no explicit cost controls,
+no request size or conversation limits, no LLM-specific evaluation suite, and
+limited observability for streamed requests. Those are reasonable omissions
+for a starter template, but they should be documented as boundaries before this
+code is reused for an internet-facing deployment.
+
+Overall assessment: **8.2 / 10 for template quality** and **6.7 / 10 for
+production readiness without additional controls**.
+
+## Review Baseline
+
+I used common full-stack and LLM-app quality dimensions:
+
+- Readability: module size, naming, local complexity, explicit control flow,
+  and framework idiom use.
+- Maintainability: separation of concerns, testability, type coverage,
+  dependency surface, duplication, CI reproducibility, and change blast radius.
+- Correctness: request validation, streaming behavior, error paths, unit tests,
+  e2e tests, visual tests, and coverage thresholds.
+- Security: secret handling, XSS resistance, dependency auditing, IaC scanning,
+  CORS shape, authentication boundaries, and abuse controls.
+- LLM-specific quality: model and parameter controls, input/output safety,
+  cost controls, prompt-injection posture, observability, and eval readiness.
+- Documentation: setup clarity, operational commands, quality gates, and
+  production caveats.
+- User experience: accessibility signals, loading/error states, keyboard
+  behavior, visual regression coverage, and Lighthouse thresholds.
+
+## Current Metrics Snapshot
+
+| Metric | Current signal |
+| --- | --- |
+| Core backend source | 281 LOC across `backend/app` |
+| Core frontend source | About 829 LOC across app, client, components, src, and CSS |
+| Backend tests | 418 LOC |
+| Frontend unit/e2e tests | About 854 LOC |
+| App-plus-test total | 2,325 LOC for core source and tests |
+| Test-to-production LOC ratio | About 1.15:1 |
+| Backend coverage floor | 100% line and branch coverage |
+| Frontend coverage floor | 90% statements/functions/lines, 75% branches |
+| Complexity gates | Ruff and fallow both cap complexity at 5 |
+| Type coverage | 100% required for backend and frontend |
+| Security gates | ESLint security rules, `pnpm audit`, `uv audit`, Checkov |
+| UX gates | Playwright e2e/visual tests and Lighthouse CI |
+
+## What Is Working Well
+
+### Readability
+
+The backend is easy to follow. `backend/app/main.py` owns the HTTP boundary,
+`backend/app/azure_client.py` owns Azure OpenAI streaming, `config.py` owns
+environment settings, and `entities.py` centralizes model and temperature
+enums. The code is explicit without being overly abstract.
+
+The frontend is also clear at the component level. `AssistantMessage`,
+`UserMessage`, `ChatInput`, and `DropdownParameter` are focused, typed, and
+tested. Rendering Markdown through `react-markdown` instead of raw HTML is a
+good readability and security choice.
+
+The one readability pressure point is `frontend/app/chat/page.tsx`, which is
+about 352 lines and contains page state, message rendering, control-panel UI,
+theme synchronization, and child component definitions in one file. That is
+still acceptable for this template, but it is the first file that should be
+split if the chat UI grows.
+
+### Maintainability
+
+The quality-tooling contract is excellent. `make qa` combines format, lint,
+type checks, schema validation, unit tests, coverage, dead-code checks,
+frontend security linting, file naming, and Checkov. CI repeats those checks
+and also runs Lighthouse. This makes regressions easier to catch before review.
+
+The repository has a conservative dependency posture. The frontend uses the
+Vercel AI SDK for chat state and streaming transport instead of custom
+streaming glue. The backend uses FastAPI, Pydantic settings, and the OpenAI
+SDK directly. That is a good default for a small app.
+
+There is little duplication. The dedicated helper modules are small, and the
+duplicated model/temperature enum values on the frontend and backend are
+understandable because they live on opposite sides of the API boundary.
+
+### Testing and Correctness
+
+The test surface is stronger than typical for a template. The backend tests
+cover successful streaming, empty-message rejection, invalid model and
+temperature validation, health checks, OpenAI error propagation, client
+construction, empty stream chunks, and mid-stream API failures.
+
+The frontend tests cover page state, model and temperature controls, loading
+state, error state, message rendering, dark-mode behavior, input validation,
+copy behavior, and component-level interactions. Playwright adds route-mocked
+e2e coverage and visual screenshots for the initial page, validation error,
+post-conversation state, and disabled input state.
+
+The strongest correctness feature is that the backend is the real trust
+boundary. `ChatRequest` uses Pydantic models and enums, rejects empty text-only
+conversations, and serializes only non-empty message text to Azure OpenAI.
+
+### Security
+
+The project has several strong baseline controls:
+
+- Secrets are loaded from `backend/.env`, which is not committed.
+- The backend does not log prompt text or response text.
+- React output avoids `dangerouslySetInnerHTML`.
+- ESLint blocks dangerous React DOM and direct DOM manipulation patterns.
+- Checkov scans Dockerfiles, workflows, YAML, and secrets surfaces.
+- CI actions are pinned to full commit SHAs.
+- Dependency audits run for both pnpm and uv.
+
+The Markdown rendering path is also reasonably safe because it uses
+`react-markdown` without enabling raw HTML rendering. That materially lowers
+the risk from model-generated HTML-like content.
+
+### Documentation
+
+`README.md` and `AGENTS.md` are unusually clear. They document runtime
+versions, service boundaries, local setup, Docker usage, API docs, quality
+commands, and hard constraints. The quality table in `README.md` is especially
+useful because it makes the intended engineering bar explicit.
+
+## Risks and Gaps
+
+### Production Boundary Controls
+
+The app currently has no authentication or authorization. That is fine for a
+template or local demo, but it is a hard blocker for production exposure.
+Any deployed version should put the chat endpoint behind identity, session
+checks, or another explicit access-control layer.
+
+The backend also lacks rate limiting, request size limits, message count
+limits, per-user quotas, and token-budget controls. For an LLM-backed service,
+those are reliability and cost controls as much as security controls. Without
+them, a single client can create runaway Azure OpenAI spend or degrade service
+for everyone else.
+
+### Configuration Fail-Fast Behavior
+
+`Settings` defaults Azure OpenAI endpoint, API key, and API version to empty
+strings. That is convenient for import-time tests and local startup, but a
+deployed service can start in a misconfigured state and fail only when the
+first chat request arrives. For production, validate required Azure settings
+at startup or use an explicit development/test settings mode.
+
+### Error Semantics for Streaming
+
+OpenAI API errors are logged and re-raised. That is useful for tests and
+server logs, but streamed clients may receive an abrupt failed stream without
+a structured user-facing error contract. If the API is meant to support more
+clients than this frontend, consider a documented streaming error convention.
+
+### Observability
+
+The backend logs timing and returned character count, but it does not include
+request IDs, model deployment metadata beyond the selected enum, user/session
+identity, latency percentiles, token usage, finish reasons, or cancellation
+signals. Those are not necessary for a template, but they become important for
+debugging production LLM behavior.
+
+The frontend has visible loading and error states, but no telemetry hooks for
+failed submissions, aborted streams, retry rates, or user-perceived latency.
+
+### LLM-Specific Evaluation Coverage
+
+The repository has strong software tests but not an LLM quality evaluation
+suite. There are no task-level golden sets, safety probes, jailbreak/prompt
+injection checks, hallucination checks, regression prompts, cost/latency
+budgets, or model-comparison reports. That is the largest LLM-specific gap if
+this template is used as the seed for a real product.
+
+### Frontend Decomposition
+
+`frontend/app/chat/page.tsx` is doing enough work that future features could
+make it harder to change safely. A practical next split would be:
+
+- `MessageList` and message rendering helpers.
+- `ControlPanel`.
+- chat transport and model/temperature state setup.
+- theme synchronization helpers.
+
+There is no urgency while the app remains small, but this is the first
+maintainability refactor I would make after adding another workflow or screen.
+
+### Dependency Update Coverage
+
+Dependabot currently covers GitHub Actions only. Runtime dependencies are
+audited in CI, which is good, but regular automated update PRs for pnpm and uv
+would reduce the chance of stale application dependencies accumulating.
+
+## Recommended Next Steps
+
+1. Document the deployment boundary: local/demo template unless auth, rate
+   limits, quotas, and request-size limits are added.
+2. Add production configuration validation for required Azure OpenAI settings,
+   while preserving test ergonomics.
+3. Add request-level limits: max messages, max characters, timeout policy, and
+   basic rate limiting.
+4. Add minimal LLM evals: a small golden prompt set, safety probes, latency
+   budget, and cost budget for the configured deployments.
+5. Add request IDs and structured metadata to backend logs.
+6. Split `frontend/app/chat/page.tsx` once the UI grows beyond the current
+   single-screen workflow.
+7. Consider Dependabot coverage for pnpm and uv in addition to GitHub Actions.
+
+## Bottom Line
+
+This is a clean, disciplined template with better automated quality controls
+than many production apps. The code is readable, testable, and appropriately
+typed. The most important improvements are not stylistic; they are operational
+and LLM-specific controls that determine whether the template remains safe and
+cost-predictable when exposed beyond local development.


### PR DESCRIPTION
## Summary

- Add `code-quality-evals/gpt-55-review.md` with a current code-quality assessment of the full-stack chatbot template.
- Cover readability, maintainability, testing, security, documentation, UX, and LLM-specific production-readiness considerations.
- Include a lightweight metrics snapshot and prioritized next steps.

## Validation

- `uv tool run --from rumdl==0.1.86 rumdl check code-quality-evals/gpt-55-review.md`
- `git diff --check`

## Notes

This PR only adds documentation. The unrelated untracked `.claude/worktrees/` directory was left untouched.