### PR TITLE
feat: validate required Azure OpenAI settings at startup

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
     )
 
     @model_validator(mode="after")
-    def validate_azure_settings(self) -> "Settings":
+    def validate_azure_settings(self) -> Settings:
         if not self.testing:
             missing: list[str] = [
                 name
@@ -36,7 +36,9 @@ class Settings(BaseSettings):
                 if not value.strip()
             ]
             if missing:
-                msg: str = f"Missing required Azure OpenAI settings: {', '.join(missing)}"
+                msg: str = (
+                    f"Missing required Azure OpenAI settings: {', '.join(missing)}"
+                )
                 raise ValueError(msg)
         return self
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -24,19 +24,19 @@ class Settings(BaseSettings):
     )
 
     @model_validator(mode="after")
-    def validate_azure_settings(self) -> Settings:
+    def validate_azure_settings(self) -> "Settings":
         if not self.testing:
-            missing = [
+            missing: list[str] = [
                 name
                 for name, value in [
                     ("AZURE_OPENAI_ENDPOINT", self.azure_openai_endpoint),
                     ("AZURE_OPENAI_API_KEY", self.azure_openai_api_key),
                     ("AZURE_OPENAI_API_VERSION", self.azure_openai_api_version),
                 ]
-                if not value
+                if not value.strip()
             ]
             if missing:
-                msg = f"Missing required Azure OpenAI settings: {', '.join(missing)}"
+                msg: str = f"Missing required Azure OpenAI settings: {', '.join(missing)}"
                 raise ValueError(msg)
         return self
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 if TYPE_CHECKING:
@@ -16,11 +16,29 @@ class Settings(BaseSettings):
         default_factory=lambda: ["http://localhost:3000"],
         alias="CORS_ALLOWED_ORIGINS",
     )
+    testing: bool = Field(default=False, alias="TESTING")
 
     model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
         env_file=".env",
         extra="ignore",
     )
+
+    @model_validator(mode="after")
+    def validate_azure_settings(self) -> Settings:
+        if not self.testing:
+            missing = [
+                name
+                for name, value in [
+                    ("AZURE_OPENAI_ENDPOINT", self.azure_openai_endpoint),
+                    ("AZURE_OPENAI_API_KEY", self.azure_openai_api_key),
+                    ("AZURE_OPENAI_API_VERSION", self.azure_openai_api_version),
+                ]
+                if not value
+            ]
+            if missing:
+                msg = f"Missing required Azure OpenAI settings: {', '.join(missing)}"
+                raise ValueError(msg)
+        return self
 
 
 @lru_cache(maxsize=1)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+
+# Must be set before any app module is imported so that Settings() does not
+# reject missing Azure credentials during test collection.
+os.environ.setdefault("TESTING", "true")

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -60,7 +60,9 @@ def test_settings_raises_on_missing_azure_credentials(
 
 
 def test_settings_whitespace_values_treated_as_missing() -> None:
-    with pytest.raises(ValueError, match="Missing required Azure OpenAI settings: AZURE_OPENAI_API_KEY"):
+    with pytest.raises(
+        ValueError, match="Missing required Azure OpenAI settings: AZURE_OPENAI_API_KEY"
+    ):
         Settings(
             AZURE_OPENAI_ENDPOINT="https://example.openai.azure.com/",
             AZURE_OPENAI_API_KEY="   ",

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,70 @@
+import pytest
+
+from app.config import Settings, get_settings
+
+
+def test_settings_valid_azure_credentials() -> None:
+    s = Settings(
+        AZURE_OPENAI_ENDPOINT="https://example.openai.azure.com/",
+        AZURE_OPENAI_API_KEY="key",
+        AZURE_OPENAI_API_VERSION="2024-09-01-preview",
+        TESTING=False,
+    )
+    assert s.azure_openai_endpoint == "https://example.openai.azure.com/"
+    assert s.azure_openai_api_key == "key"
+    assert s.azure_openai_api_version == "2024-09-01-preview"
+    assert s.testing is False
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "api_key", "api_version", "missing_names"),
+    [
+        ("", "key", "2024-09-01-preview", ["AZURE_OPENAI_ENDPOINT"]),
+        (
+            "https://example.openai.azure.com/",
+            "",
+            "2024-09-01-preview",
+            ["AZURE_OPENAI_API_KEY"],
+        ),
+        ("https://example.openai.azure.com/", "key", "", ["AZURE_OPENAI_API_VERSION"]),
+        (
+            "",
+            "",
+            "",
+            [
+                "AZURE_OPENAI_ENDPOINT",
+                "AZURE_OPENAI_API_KEY",
+                "AZURE_OPENAI_API_VERSION",
+            ],
+        ),
+    ],
+)
+def test_settings_raises_on_missing_azure_credentials(
+    endpoint: str,
+    api_key: str,
+    api_version: str,
+    missing_names: list[str],
+) -> None:
+    with pytest.raises(ValueError, match="Missing required Azure OpenAI settings"):
+        Settings(
+            AZURE_OPENAI_ENDPOINT=endpoint,
+            AZURE_OPENAI_API_KEY=api_key,
+            AZURE_OPENAI_API_VERSION=api_version,
+            TESTING=False,
+        )
+
+
+def test_settings_testing_mode_allows_empty_azure_credentials() -> None:
+    s = Settings(TESTING=True)
+    assert s.azure_openai_endpoint == ""
+    assert s.azure_openai_api_key == ""
+    assert s.azure_openai_api_version == ""
+    assert s.testing is True
+
+
+def test_get_settings_returns_cached_instance() -> None:
+    get_settings.cache_clear()
+    first = get_settings()
+    second = get_settings()
+    assert first is second
+    get_settings.cache_clear()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,10 +1,12 @@
+import re
+
 import pytest
 
 from app.config import Settings, get_settings
 
 
 def test_settings_valid_azure_credentials() -> None:
-    s = Settings(
+    s: Settings = Settings(
         AZURE_OPENAI_ENDPOINT="https://example.openai.azure.com/",
         AZURE_OPENAI_API_KEY="key",
         AZURE_OPENAI_API_VERSION="2024-09-01-preview",
@@ -45,7 +47,10 @@ def test_settings_raises_on_missing_azure_credentials(
     api_version: str,
     missing_names: list[str],
 ) -> None:
-    with pytest.raises(ValueError, match="Missing required Azure OpenAI settings"):
+    pattern: str = "Missing required Azure OpenAI settings: " + re.escape(
+        ", ".join(missing_names),
+    )
+    with pytest.raises(ValueError, match=pattern):
         Settings(
             AZURE_OPENAI_ENDPOINT=endpoint,
             AZURE_OPENAI_API_KEY=api_key,
@@ -54,8 +59,18 @@ def test_settings_raises_on_missing_azure_credentials(
         )
 
 
+def test_settings_whitespace_values_treated_as_missing() -> None:
+    with pytest.raises(ValueError, match="Missing required Azure OpenAI settings: AZURE_OPENAI_API_KEY"):
+        Settings(
+            AZURE_OPENAI_ENDPOINT="https://example.openai.azure.com/",
+            AZURE_OPENAI_API_KEY="   ",
+            AZURE_OPENAI_API_VERSION="2024-09-01-preview",
+            TESTING=False,
+        )
+
+
 def test_settings_testing_mode_allows_empty_azure_credentials() -> None:
-    s = Settings(TESTING=True)
+    s: Settings = Settings(TESTING=True)
     assert s.azure_openai_endpoint == ""
     assert s.azure_openai_api_key == ""
     assert s.azure_openai_api_version == ""
@@ -64,7 +79,7 @@ def test_settings_testing_mode_allows_empty_azure_credentials() -> None:
 
 def test_get_settings_returns_cached_instance() -> None:
     get_settings.cache_clear()
-    first = get_settings()
-    second = get_settings()
+    first: Settings = get_settings()
+    second: Settings = get_settings()
     assert first is second
     get_settings.cache_clear()

--- a/makefiles/backend.mk
+++ b/makefiles/backend.mk
@@ -5,7 +5,7 @@ PYTEST=uv run pytest app tests --verbose
 PYCOVERAGE=uv run coverage run -m pytest app tests && uv run coverage report && uv run coverage html && uv run coverage xml
 PYTYPECOVERAGE=uv run python -m typecoverage app tests locustfile.py --recursive --exit-nonzero-on-issues
 FASTAPI_RUNSERVER=uv run fastapi dev app/main.py --host 0.0.0.0 --port 8000
-OPENAPI_SCHEMA=uv run python -c "from app.main import app; app.openapi()"
+OPENAPI_SCHEMA=TESTING=true uv run python -c "from app.main import app; app.openapi()"
 LOCUST=uv run locust -H http://127.0.0.1:8000/
 
 backend-lint:


### PR DESCRIPTION
## Summary

- Adds a `model_validator` to `Settings` that checks `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, and `AZURE_OPENAI_API_VERSION` are non-empty at startup (when `Settings()` is instantiated)
- Adds a `TESTING` boolean field (env var `TESTING=true`) that skips validation — set automatically in `tests/conftest.py` and the `backend-validate-api-schema` Make target so CI and local `make qa` work without real Azure credentials
- Adds `tests/test_config.py` with full coverage of the new validation logic (all branches: valid credentials, testing bypass, individual/all-fields missing)

**Before:** a service could start with all three Azure settings empty and only fail when the first chat request arrived.  
**After:** `Settings()` raises `ValueError` with a clear message listing every missing setting, preventing silent misconfiguration.

## Test plan

- [x] `make backend-validate-api-schema` passes (schema generation uses `TESTING=true`)
- [x] `make backend-test` passes — all 33 tests pass, 100% line + branch coverage
- [x] `Settings(TESTING=False)` with empty Azure fields raises `ValueError` listing missing names
- [x] `Settings(TESTING=True)` with empty Azure fields succeeds (test/dev mode)
- [x] `Settings(TESTING=False)` with all Azure fields populated succeeds