### PR TITLE
refactor: decompose chat page, expand Dependabot, trim stale eval docs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Keep frontend (pnpm) dependencies up-to-date
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+
+  # Keep backend (uv) dependencies up-to-date
+  - package-ecosystem: "uv"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -61,7 +61,8 @@ def test_settings_raises_on_missing_azure_credentials(
 
 def test_settings_whitespace_values_treated_as_missing() -> None:
     with pytest.raises(
-        ValueError, match="Missing required Azure OpenAI settings: AZURE_OPENAI_API_KEY"
+        ValueError,
+        match="Missing required Azure OpenAI settings: AZURE_OPENAI_API_KEY",
     ):
         Settings(
             AZURE_OPENAI_ENDPOINT="https://example.openai.azure.com/",

--- a/code-quality-evals/gpt-55-review.md
+++ b/code-quality-evals/gpt-55-review.md
@@ -26,14 +26,6 @@ those are reliability and cost controls as much as security controls. Without
 them, a single client can create runaway Azure OpenAI spend or degrade service
 for everyone else.
 
-### Configuration Fail-Fast Behavior
-
-`Settings` defaults Azure OpenAI endpoint, API key, and API version to empty
-strings. That is convenient for import-time tests and local startup, but a
-deployed service can start in a misconfigured state and fail only when the
-first chat request arrives. For production, validate required Azure settings
-at startup or use an explicit development/test settings mode.
-
 ### Error Semantics for Streaming
 
 OpenAI API errors are logged and re-raised. That is useful for tests and
@@ -60,37 +52,12 @@ injection checks, hallucination checks, regression prompts, cost/latency
 budgets, or model-comparison reports. That is the largest LLM-specific gap if
 this template is used as the seed for a real product.
 
-### Frontend Decomposition
-
-`frontend/app/chat/page.tsx` is doing enough work that future features could
-make it harder to change safely. A practical next split would be:
-
-- `MessageList` and message rendering helpers.
-- `ControlPanel`.
-- chat transport and model/temperature state setup.
-- theme synchronization helpers.
-
-There is no urgency while the app remains small, but this is the first
-maintainability refactor I would make after adding another workflow or screen.
-
-### Dependency Update Coverage
-
-Dependabot currently covers GitHub Actions only. Runtime dependencies are
-audited in CI, which is good, but regular automated update PRs for pnpm and uv
-would reduce the chance of stale application dependencies accumulating.
-
 ## Recommended Next Steps
 
 1. Document the deployment boundary: local/demo template unless auth, rate
    limits, quotas, and request-size limits are added.
-2. Add production configuration validation for required Azure OpenAI settings,
-   while preserving test ergonomics.
-3. Add request-level limits: max messages, max characters, timeout policy, and
+2. Add request-level limits: max messages, max characters, timeout policy, and
    basic rate limiting.
-4. Add minimal LLM evals: a small golden prompt set, safety probes, latency
+3. Add minimal LLM evals: a small golden prompt set, safety probes, latency
    budget, and cost budget for the configured deployments.
-5. Add request IDs and structured metadata to backend logs.
-6. Split `frontend/app/chat/page.tsx` once the UI grows beyond the current
-   single-screen workflow.
-7. Consider Dependabot coverage for pnpm and uv in addition to GitHub Actions.
-
+4. Add request IDs and structured metadata to backend logs.

--- a/code-quality-evals/opus-47-review.md
+++ b/code-quality-evals/opus-47-review.md
@@ -36,11 +36,6 @@ streamed via Azure OpenAI
 
 ### Weaknesses
 
-- **`renderMessage` in page.tsx**: This free function lives inside a
-  component module and operates on `UIMessage` objects. It would be
-  easier to follow as a dedicated `<Message>` component — the current
-  placement is a minor readability bump for reviewers unfamiliar with
-  the file.
 - **Inline MUI `sx` props**: Several components pass substantial style
   objects inline rather than hoisting them to named constants. This is
   idiomatic MUI but reduces scannability when styles are long.
@@ -190,16 +185,6 @@ streamed via Azure OpenAI
 
 ### Score: 9.5 / 10
 
-### Weaknesses
-
-- **No explicit WCAG level target in documentation**: The project
-  clearly aims for AA compliance, but this is not stated. Documenting
-  the target level would help reviewers understand what to test against.
-- **Dark mode is default without system preference detection**: The
-  initial state is `darkMode = true` regardless of the user's
-  `prefers-color-scheme`. A user in a light environment may be
-  surprised on first load.
-
 ---
 
 ## 10. Dependency Health
@@ -230,11 +215,7 @@ streamed via Azure OpenAI
    output plus `openapi-typescript` to generate frontend types.
    Eliminates the risk of schema drift between Pydantic models and
    TypeScript types.
-4. **Detect `prefers-color-scheme`**: Replace the hardcoded
-   `darkMode = true` default with
-   `window.matchMedia('(prefers-color-scheme: dark)').matches` so the
-   initial render matches the user's OS preference.
-5. **Add a circuit breaker**: Repeated Azure OpenAI failures currently
+4. **Add a circuit breaker**: Repeated Azure OpenAI failures currently
    result in repeated timeouts. A circuit breaker (`pybreaker`) would
    fail fast after a threshold and recover automatically.
 

--- a/frontend/app/chat/page.test.tsx
+++ b/frontend/app/chat/page.test.tsx
@@ -1,319 +1,251 @@
+import { createTheme } from "@mui/material/styles";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 
 // Hoist mock functions so they can be used inside vi.mock factories
-const { mockSendMessage, mockRegenerate, mockUseChat } = vi.hoisted(() => ({
-  mockSendMessage: vi.fn().mockResolvedValue(undefined),
-  mockRegenerate: vi.fn().mockResolvedValue(undefined),
-  mockUseChat: vi.fn(),
+const {
+  mockUseChatSetup,
+  mockUseDarkMode,
+  mockToggleDarkMode,
+  mockHandleSendMessage,
+  mockHandleRegenerateResponse,
+} = vi.hoisted(() => ({
+  mockUseChatSetup: vi.fn(),
+  mockUseDarkMode: vi.fn(),
+  mockToggleDarkMode: vi.fn(),
+  mockHandleSendMessage: vi.fn().mockResolvedValue(undefined),
+  mockHandleRegenerateResponse: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("@ai-sdk/react", () => ({
-  useChat: mockUseChat,
+vi.mock("@/client/useChatSetup", () => ({
+  useChatSetup: mockUseChatSetup,
 }));
 
-vi.mock("ai", () => ({
-  TextStreamChatTransport: class {},
+vi.mock("@/client/useDarkMode", () => ({
+  useDarkMode: mockUseDarkMode,
 }));
 
-// Mock child components so we can test page.tsx logic in isolation
-vi.mock("@/components/messages/AssistantMessage", () => ({
+// Mock extracted components so we can test page.tsx logic in isolation
+vi.mock("@/components/messages/MessageList", () => ({
   default: ({
-    content,
-    isFirstMessage,
+    messages,
+    assistantIsLoading,
+    error,
   }: {
-    content: string;
-    isFirstMessage: boolean;
+    messages: unknown[];
+    assistantIsLoading: boolean;
+    error: Error | undefined;
   }) => (
     <div
-      data-testid="assistant-message"
-      data-first-message={String(isFirstMessage)}
-    >
-      {content}
+      data-testid="message-list"
+      data-loading={String(assistantIsLoading)}
+      data-error={error?.message ?? ""}
+      data-message-count={String(messages.length)}
+    />
+  ),
+}));
+
+vi.mock("@/components/ControlPanel", () => ({
+  default: ({
+    model,
+    temperature,
+    canRegenerate,
+    disabled,
+    setModel,
+    setTemperature,
+    onToggleDarkMode,
+    onRegenerate,
+    onSendMessage,
+  }: {
+    model: string;
+    temperature: string;
+    canRegenerate: boolean;
+    disabled: boolean;
+    setModel: (m: string) => void;
+    setTemperature: (t: string) => void;
+    onToggleDarkMode: () => void;
+    onRegenerate: () => void;
+    onSendMessage: (msg: string) => Promise<void>;
+  }) => (
+    <div data-testid="control-panel">
+      <span data-testid="cp-model">{model}</span>
+      <span data-testid="cp-temperature">{temperature}</span>
+      <span data-testid="cp-can-regenerate">{String(canRegenerate)}</span>
+      <span data-testid="cp-disabled">{String(disabled)}</span>
+      <button
+        type="button"
+        data-testid="cp-set-model"
+        onClick={() => setModel("gpt-4o-mini")}
+      >
+        Set Model
+      </button>
+      <button
+        type="button"
+        data-testid="cp-set-temperature"
+        onClick={() => setTemperature("CREATIVE")}
+      >
+        Set Temp
+      </button>
+      <button
+        type="button"
+        data-testid="cp-toggle-dark"
+        onClick={onToggleDarkMode}
+      >
+        Toggle Dark
+      </button>
+      <button
+        type="button"
+        data-testid="cp-regenerate"
+        onClick={onRegenerate}
+      >
+        Regenerate
+      </button>
+      <button
+        type="button"
+        data-testid="cp-send"
+        onClick={() => void onSendMessage("hi")}
+      >
+        Send
+      </button>
     </div>
   ),
 }));
 
-vi.mock("@/components/messages/UserMessage", () => ({
-  default: ({ content }: { content: string }) => (
-    <div data-testid="user-message">{content}</div>
-  ),
-}));
-
-vi.mock("@/components/messages/ChatInput", () => ({
-  default: ({
-    onSendMessage,
-    disabled,
-  }: {
-    onSendMessage: (msg: string) => Promise<void>;
-    disabled: boolean;
-  }) => (
-    <button
-      type="button"
-      data-testid="chat-input-send"
-      data-disabled={String(disabled)}
-      onClick={() => void onSendMessage("test message")}
-    >
-      Send
-    </button>
-  ),
-}));
-
-vi.mock("@/components/parameters/DropdownParameter", () => ({
-  default: ({
-    onChange,
-    ariaLabel,
-    options,
-    value,
-  }: {
-    onChange: (v: string) => void;
-    ariaLabel: string;
-    options: Array<{ value: string; label: string }>;
-    value: string;
-  }) => (
-    <select
-      aria-label={ariaLabel}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-    >
-      {options.map((o) => (
-        <option
-          key={o.value}
-          value={o.value}
-        >
-          {o.label}
-        </option>
-      ))}
-    </select>
-  ),
-}));
-
+import { AssistantModel, AssistantTemperature } from "@/client/types/assistant";
 import Home from "./page";
-
-type TestMessage = {
-  id: string;
-  role: string;
-  parts: Array<{ type: string; text?: string }>;
-};
 
 const INITIAL_MESSAGES = [
   {
     id: "initial-message",
     role: "assistant" as const,
-    parts: [
-      {
-        type: "text" as const,
-        text: "Hi, I am a chat bot. How can I help you today?",
-      },
-    ],
+    parts: [{ type: "text" as const, text: "Hi, I am a chat bot." }],
   },
 ];
 
-const WITH_USER_MESSAGE: TestMessage[] = [
-  ...INITIAL_MESSAGES,
-  {
-    id: "u1",
-    role: "user" as const,
-    parts: [{ type: "text" as const, text: "Hi" }],
-  },
-];
-
-function setupChat(
+function setupMocks(
   overrides: Partial<{
-    messages: TestMessage[];
-    status: string;
+    messages: typeof INITIAL_MESSAGES;
+    assistantIsLoading: boolean;
+    hasUserMessage: boolean;
     error: Error | undefined;
+    darkMode: boolean;
   }> = {},
 ) {
-  mockUseChat.mockReturnValue({
-    messages: INITIAL_MESSAGES,
-    sendMessage: mockSendMessage,
-    regenerate: mockRegenerate,
-    error: undefined,
-    status: "idle",
-    ...overrides,
+  const {
+    messages = INITIAL_MESSAGES,
+    assistantIsLoading = false,
+    hasUserMessage = false,
+    error = undefined,
+    darkMode = false,
+  } = overrides;
+
+  mockUseChatSetup.mockReturnValue({
+    messages,
+    assistantIsLoading,
+    hasUserMessage,
+    error,
+    handleSendMessage: mockHandleSendMessage,
+    handleRegenerateResponse: mockHandleRegenerateResponse,
   });
-}
 
-class MockMediaQueryList extends EventTarget implements MediaQueryList {
-  readonly matches: boolean;
-  readonly media: string;
-  onchange:
-    | ((this: MediaQueryList, ev: MediaQueryListEvent) => unknown)
-    | null = null;
-
-  constructor(matches: boolean, media: string) {
-    super();
-    this.matches = matches;
-    this.media = media;
-  }
-
-  addListener(): void {}
-  removeListener(): void {}
-}
-
-function mockMatchMedia(prefersDark: boolean) {
-  vi.stubGlobal(
-    "matchMedia",
-    (query: string): MediaQueryList =>
-      new MockMediaQueryList(
-        prefersDark && query === "(prefers-color-scheme: dark)",
-        query,
-      ),
-  );
+  mockUseDarkMode.mockReturnValue({
+    darkMode,
+    theme: createTheme({ palette: { mode: darkMode ? "dark" : "light" } }),
+    toggleDarkMode: mockToggleDarkMode,
+  });
 }
 
 describe("Home page", () => {
   beforeEach(() => {
-    mockMatchMedia(true);
-    setupChat();
+    setupMocks();
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  test("renders initial assistant message marked as first message", () => {
-    render(<Home />);
-    const msg = screen.getByTestId("assistant-message");
-    expect(msg).toHaveTextContent("Hi, I am a chat bot");
-    expect(msg).toHaveAttribute("data-first-message", "true");
+    vi.clearAllMocks();
   });
 
   test("renders main landmark, page heading, and skip link", () => {
     render(<Home />);
     expect(screen.getByRole("main")).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", {
-        level: 1,
-        name: "Chatbot Template",
-      }),
+      screen.getByRole("heading", { level: 1, name: "Chatbot Template" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "Skip to Message" }),
     ).toHaveAttribute("href", "#message-input");
   });
 
-  test("renders user messages via renderMessage", () => {
-    setupChat({
-      messages: [
-        ...INITIAL_MESSAGES,
-        {
-          id: "u1",
-          role: "user" as const,
-          parts: [{ type: "text" as const, text: "Hello bot" }],
-        },
-      ],
-    });
+  test("passes assistantIsLoading to MessageList", () => {
+    setupMocks({ assistantIsLoading: true });
     render(<Home />);
-    expect(screen.getByTestId("user-message")).toHaveTextContent("Hello bot");
-  });
-
-  test("shows CircularProgress when status is submitted", () => {
-    setupChat({ status: "submitted" });
-    render(<Home />);
-    expect(screen.getByRole("status")).toHaveTextContent("Generating…");
-  });
-
-  test("shows CircularProgress when status is streaming", () => {
-    setupChat({ status: "streaming" });
-    render(<Home />);
-    expect(screen.getByRole("status")).toHaveTextContent("Generating…");
-  });
-
-  test("shows error Alert when error is present", () => {
-    setupChat({ error: new Error("Network error") });
-    render(<Home />);
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "Something went wrong. Try sending your message again. Details: Network error",
+    expect(screen.getByTestId("message-list")).toHaveAttribute(
+      "data-loading",
+      "true",
     );
   });
 
-  test("starts in dark mode when system prefers dark", () => {
+  test("passes error to MessageList", () => {
+    setupMocks({ error: new Error("oops") });
     render(<Home />);
-    expect(screen.getByLabelText("Switch to light mode")).toBeInTheDocument();
+    expect(screen.getByTestId("message-list")).toHaveAttribute(
+      "data-error",
+      "oops",
+    );
   });
 
-  test("starts in light mode when system prefers light", () => {
-    mockMatchMedia(false);
+  test("passes model to ControlPanel", () => {
     render(<Home />);
-    expect(screen.getByLabelText("Switch to dark mode")).toBeInTheDocument();
+    expect(screen.getByTestId("cp-model")).toHaveTextContent(
+      AssistantModel.FULL,
+    );
   });
 
-  test("toggles from dark to light mode", () => {
+  test("passes temperature to ControlPanel", () => {
     render(<Home />);
-    fireEvent.click(screen.getByLabelText("Switch to light mode"));
-    expect(screen.getByLabelText("Switch to dark mode")).toBeInTheDocument();
+    expect(screen.getByTestId("cp-temperature")).toHaveTextContent(
+      AssistantTemperature.BALANCED,
+    );
   });
 
-  test("regenerate button is disabled when no user messages", () => {
+  test("passes canRegenerate as true when hasUserMessage is true", () => {
+    setupMocks({ hasUserMessage: true });
     render(<Home />);
-    expect(screen.getByLabelText("Regenerate response")).toBeDisabled();
+    expect(screen.getByTestId("cp-can-regenerate")).toHaveTextContent("true");
   });
 
-  test("regenerate invokes chat retry when there is a user message and not loading", () => {
-    setupChat({ messages: WITH_USER_MESSAGE });
+  test("passes disabled as true when assistantIsLoading is true", () => {
+    setupMocks({ assistantIsLoading: true });
     render(<Home />);
-    fireEvent.click(screen.getByLabelText("Regenerate response"));
-    expect(mockRegenerate).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("cp-disabled")).toHaveTextContent("true");
   });
 
-  test("regenerate does not fire when disabled (loading)", () => {
-    setupChat({ status: "streaming", messages: WITH_USER_MESSAGE });
+  test("model state updates when setModel is called from ControlPanel", () => {
     render(<Home />);
-    fireEvent.click(screen.getByLabelText("Regenerate response"));
-    expect(mockRegenerate).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("cp-set-model"));
+    expect(screen.getByTestId("cp-model")).toHaveTextContent("gpt-4o-mini");
   });
 
-  test("syncs browser chrome metadata with the selected theme", () => {
-    const meta = document.createElement("meta");
-    meta.name = "theme-color";
-    document.head.append(meta);
-
+  test("temperature state updates when setTemperature is called from ControlPanel", () => {
     render(<Home />);
-    expect(document.documentElement.style.colorScheme).toBe("dark");
-    expect(meta.content).toBe("#121212");
-
-    fireEvent.click(screen.getByLabelText("Switch to light mode"));
-    expect(document.documentElement.style.colorScheme).toBe("light");
-    expect(meta.content).toBe("#ffffff");
-
-    meta.remove();
+    fireEvent.click(screen.getByTestId("cp-set-temperature"));
+    expect(screen.getByTestId("cp-temperature")).toHaveTextContent("CREATIVE");
   });
 
-  test("sends message from the chat input", async () => {
+  test("toggleDarkMode from useDarkMode is wired to ControlPanel", () => {
     render(<Home />);
-    fireEvent.click(screen.getByTestId("chat-input-send"));
-    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId("cp-toggle-dark"));
+    expect(mockToggleDarkMode).toHaveBeenCalledTimes(1);
   });
 
-  test("updates model selection from the dropdown", async () => {
+  test("handleRegenerateResponse from useChatSetup is wired to ControlPanel", () => {
     render(<Home />);
-    const modelSelect = screen.getByLabelText(/Select assistant model/i);
-    fireEvent.change(modelSelect, { target: { value: "gpt-4o-mini" } });
-    expect(modelSelect).toHaveValue("gpt-4o-mini");
+    fireEvent.click(screen.getByTestId("cp-regenerate"));
+    expect(mockHandleRegenerateResponse).toHaveBeenCalledTimes(1);
   });
 
-  test("updates temperature selection from the dropdown", async () => {
+  test("handleSendMessage from useChatSetup is wired to ControlPanel", () => {
     render(<Home />);
-    const tempSelect = screen.getByLabelText(/Select assistant temperature/i);
-    fireEvent.change(tempSelect, { target: { value: "CREATIVE" } });
-    expect(tempSelect).toHaveValue("CREATIVE");
-  });
-
-  test("non-text message parts yield empty string in renderMessage", () => {
-    setupChat({
-      messages: [
-        {
-          id: "a1",
-          role: "assistant" as const,
-          parts: [{ type: "step-start" }],
-        },
-      ],
-    });
-    render(<Home />);
-    // Should render without crashing; non-text parts map to ""
-    const msg = screen.getByTestId("assistant-message");
-    expect(msg).toHaveTextContent("");
+    fireEvent.click(screen.getByTestId("cp-send"));
+    expect(mockHandleSendMessage).toHaveBeenCalledWith("hi");
   });
 });

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -1,47 +1,13 @@
 "use client";
 
-import { type UIMessage, useChat } from "@ai-sdk/react";
-import DarkModeIcon from "@mui/icons-material/DarkMode";
-import LightModeIcon from "@mui/icons-material/LightMode";
-import PsychologyIcon from "@mui/icons-material/Psychology";
-import RefreshIcon from "@mui/icons-material/Refresh";
-import ThermostatIcon from "@mui/icons-material/Thermostat";
-import {
-  Alert,
-  Box,
-  CircularProgress,
-  Container,
-  CssBaseline,
-  IconButton,
-  Stack,
-  Tooltip,
-  Typography,
-} from "@mui/material";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
-import { TextStreamChatTransport } from "ai";
-import { useEffect, useMemo, useState } from "react";
-import { getModelDisplay, getTemperatureDisplay } from "@/client/helpers";
+import { Box, Container, CssBaseline, Typography } from "@mui/material";
+import { ThemeProvider } from "@mui/material/styles";
+import { useState } from "react";
 import { AssistantModel, AssistantTemperature } from "@/client/types/assistant";
-import AssistantMessage from "@/components/messages/AssistantMessage";
-import ChatInput from "@/components/messages/ChatInput";
-import UserMessage from "@/components/messages/UserMessage";
-import DropdownParameter from "@/components/parameters/DropdownParameter";
-
-const INITIAL_MESSAGE_ID = "initial-message";
-const CHAT_API_URL =
-  import.meta.env.VITE_CHAT_API_URL ?? "http://localhost:8000/api/v1/chat";
-const INITIAL_MESSAGES: UIMessage[] = [
-  {
-    id: INITIAL_MESSAGE_ID,
-    role: "assistant",
-    parts: [
-      { type: "text", text: "Hi, I am a chat bot. How can I help you today?" },
-    ],
-  },
-];
-
-const DARK_THEME_COLOR = "#121212";
-const LIGHT_THEME_COLOR = "#ffffff";
+import { useChatSetup } from "@/client/useChatSetup";
+import { useDarkMode } from "@/client/useDarkMode";
+import ControlPanel from "@/components/ControlPanel";
+import MessageList from "@/components/messages/MessageList";
 
 const VISUALLY_HIDDEN_SX = {
   border: 0,
@@ -77,234 +43,20 @@ const SKIP_LINK_SX = {
   },
 } as const;
 
-const MODEL_OPTIONS = [
-  { value: AssistantModel.FULL, label: "GPT-4o" },
-  { value: AssistantModel.MINI, label: "GPT-4o Mini" },
-];
-
-const TEMPERATURE_OPTIONS = [
-  {
-    value: AssistantTemperature.DETERMINISTIC,
-    label: "0.2 - More Deterministic",
-  },
-  { value: AssistantTemperature.BALANCED, label: "0.7 - Balanced" },
-  { value: AssistantTemperature.CREATIVE, label: "0.9 - More Creative" },
-];
-
-function renderMessage(message: UIMessage) {
-  const content = message.parts
-    .map((part) => (part.type === "text" ? part.text : ""))
-    .join("");
-
-  return message.role === "user" ? (
-    <UserMessage
-      key={message.id}
-      content={content}
-    />
-  ) : (
-    <AssistantMessage
-      key={message.id}
-      content={content}
-      isFirstMessage={message.id === INITIAL_MESSAGE_ID}
-    />
-  );
-}
-
-interface MessageListProps {
-  messages: UIMessage[];
-  assistantIsLoading: boolean;
-  error: Error | undefined;
-}
-
-function MessageList({
-  messages,
-  assistantIsLoading,
-  error,
-}: MessageListProps) {
-  return (
-    <Box
-      component="section"
-      aria-label="Chat conversation"
-      sx={{ flexGrow: 1, overflowY: "auto", p: 2 }}
-    >
-      <Stack spacing={2}>
-        {messages.map(renderMessage)}
-        {assistantIsLoading && (
-          <Stack
-            aria-live="polite"
-            direction="row"
-            role="status"
-            spacing={1}
-            sx={{ alignItems: "center" }}
-          >
-            <CircularProgress
-              aria-hidden={true}
-              size={20}
-            />
-            <Typography variant="body2">Generating…</Typography>
-          </Stack>
-        )}
-        {error && (
-          <Alert severity="error">
-            Something went wrong. Try sending your message again. Details:{" "}
-            {error.message}
-          </Alert>
-        )}
-      </Stack>
-    </Box>
-  );
-}
-
-interface DarkModeToggleProps {
-  darkMode: boolean;
-  onToggle: () => void;
-}
-
-function DarkModeToggle({ darkMode, onToggle }: DarkModeToggleProps) {
-  return (
-    <Tooltip title={darkMode ? "Switch to Light Mode" : "Switch to Dark Mode"}>
-      <IconButton
-        onClick={onToggle}
-        aria-label={darkMode ? "Switch to light mode" : "Switch to dark mode"}
-      >
-        {darkMode ? <LightModeIcon /> : <DarkModeIcon />}
-      </IconButton>
-    </Tooltip>
-  );
-}
-
-interface ControlPanelProps {
-  model: AssistantModel;
-  setModel: (m: AssistantModel) => void;
-  temperature: AssistantTemperature;
-  setTemperature: (t: AssistantTemperature) => void;
-  onRegenerate: () => void;
-  canRegenerate: boolean;
-  darkMode: boolean;
-  onToggleDarkMode: () => void;
-  disabled: boolean;
-  onSendMessage: (message: string) => Promise<void>;
-}
-
-function ControlPanel({
-  model,
-  setModel,
-  temperature,
-  setTemperature,
-  onRegenerate,
-  canRegenerate,
-  darkMode,
-  onToggleDarkMode,
-  disabled,
-  onSendMessage,
-}: ControlPanelProps) {
-  return (
-    <Box sx={{ p: 2 }}>
-      <Stack
-        direction="row"
-        spacing={2}
-        sx={{ mb: 2 }}
-      >
-        <DropdownParameter
-          value={model}
-          onChange={setModel}
-          icon={<PsychologyIcon />}
-          tooltipTitle={
-            <>
-              Choose Assistant Model
-              <br />
-              (Current: {getModelDisplay(model)})
-            </>
-          }
-          ariaLabel={`Select assistant model. Current model: ${getModelDisplay(model)}`}
-          options={MODEL_OPTIONS}
-        />
-        <DropdownParameter
-          value={temperature}
-          onChange={setTemperature}
-          icon={<ThermostatIcon />}
-          tooltipTitle={
-            <>
-              Choose Temperature
-              <br />
-              (Current: {getTemperatureDisplay(temperature)})
-            </>
-          }
-          ariaLabel={`Select assistant temperature. Current temperature: ${getTemperatureDisplay(temperature)}`}
-          options={TEMPERATURE_OPTIONS}
-        />
-        <Tooltip title="Regenerate Response">
-          <span>
-            <IconButton
-              disabled={disabled || !canRegenerate}
-              onClick={onRegenerate}
-              aria-label="Regenerate response"
-            >
-              <RefreshIcon />
-            </IconButton>
-          </span>
-        </Tooltip>
-        <DarkModeToggle
-          darkMode={darkMode}
-          onToggle={onToggleDarkMode}
-        />
-      </Stack>
-      <ChatInput
-        onSendMessage={onSendMessage}
-        disabled={disabled}
-      />
-    </Box>
-  );
-}
-
-function syncBrowserTheme(darkMode: boolean) {
-  document.documentElement.style.colorScheme = darkMode ? "dark" : "light";
-  document
-    .querySelector<HTMLMetaElement>('meta[name="theme-color"]')
-    ?.setAttribute("content", darkMode ? DARK_THEME_COLOR : LIGHT_THEME_COLOR);
-}
-
 export default function Home() {
   const [model, setModel] = useState<AssistantModel>(AssistantModel.FULL);
   const [temperature, setTemperature] = useState<AssistantTemperature>(
     AssistantTemperature.BALANCED,
   );
-  const [darkMode, setDarkMode] = useState(() =>
-    typeof window !== "undefined" && typeof window.matchMedia === "function"
-      ? window.matchMedia("(prefers-color-scheme: dark)").matches
-      : false,
-  );
-
-  useEffect(() => {
-    syncBrowserTheme(darkMode);
-  }, [darkMode]);
-
-  const transport = useMemo(
-    () => new TextStreamChatTransport({ api: CHAT_API_URL }),
-    [],
-  );
-  const { messages, sendMessage, regenerate, error, status } = useChat({
-    messages: INITIAL_MESSAGES,
-    transport,
-    experimental_throttle: 50,
-  });
-  const assistantIsLoading = status === "submitted" || status === "streaming";
-  const hasUserMessage = messages.some((message) => message.role === "user");
-
-  const theme = useMemo(
-    () => createTheme({ palette: { mode: darkMode ? "dark" : "light" } }),
-    [darkMode],
-  );
-
-  const handleSendMessage = async (message: string) => {
-    await sendMessage({ text: message }, { body: { model, temperature } });
-  };
-
-  const handleRegenerateResponse = async () => {
-    if (hasUserMessage) {
-      await regenerate({ body: { model, temperature } });
-    }
-  };
+  const { darkMode, theme, toggleDarkMode } = useDarkMode();
+  const {
+    messages,
+    assistantIsLoading,
+    hasUserMessage,
+    error,
+    handleSendMessage,
+    handleRegenerateResponse,
+  } = useChatSetup(model, temperature);
 
   return (
     <ThemeProvider theme={theme}>
@@ -346,7 +98,7 @@ export default function Home() {
           onRegenerate={handleRegenerateResponse}
           canRegenerate={hasUserMessage}
           darkMode={darkMode}
-          onToggleDarkMode={() => setDarkMode((prev) => !prev)}
+          onToggleDarkMode={toggleDarkMode}
           disabled={assistantIsLoading}
           onSendMessage={handleSendMessage}
         />

--- a/frontend/client/chatConstants.test.ts
+++ b/frontend/client/chatConstants.test.ts
@@ -1,0 +1,25 @@
+import {
+  CHAT_API_URL,
+  INITIAL_MESSAGE_ID,
+  INITIAL_MESSAGES,
+} from "./chatConstants";
+
+describe("chatConstants", () => {
+  test("INITIAL_MESSAGE_ID is initial-message", () => {
+    expect(INITIAL_MESSAGE_ID).toBe("initial-message");
+  });
+
+  test("CHAT_API_URL falls back to localhost when env var is unset", () => {
+    expect(CHAT_API_URL).toBe("http://localhost:8000/api/v1/chat");
+  });
+
+  test("INITIAL_MESSAGES contains one assistant message with matching id", () => {
+    expect(INITIAL_MESSAGES).toHaveLength(1);
+    expect(INITIAL_MESSAGES[0].role).toBe("assistant");
+    expect(INITIAL_MESSAGES[0].id).toBe(INITIAL_MESSAGE_ID);
+    expect(INITIAL_MESSAGES[0].parts[0]).toEqual({
+      type: "text",
+      text: "Hi, I am a chat bot. How can I help you today?",
+    });
+  });
+});

--- a/frontend/client/chatConstants.ts
+++ b/frontend/client/chatConstants.ts
@@ -1,0 +1,16 @@
+import type { UIMessage } from "@ai-sdk/react";
+
+const INITIAL_MESSAGE_ID = "initial-message";
+const CHAT_API_URL =
+  import.meta.env.VITE_CHAT_API_URL ?? "http://localhost:8000/api/v1/chat";
+const INITIAL_MESSAGES: UIMessage[] = [
+  {
+    id: INITIAL_MESSAGE_ID,
+    role: "assistant",
+    parts: [
+      { type: "text", text: "Hi, I am a chat bot. How can I help you today?" },
+    ],
+  },
+];
+
+export { CHAT_API_URL, INITIAL_MESSAGE_ID, INITIAL_MESSAGES };

--- a/frontend/client/useChatSetup.test.tsx
+++ b/frontend/client/useChatSetup.test.tsx
@@ -1,0 +1,150 @@
+import { renderHook } from "@testing-library/react";
+import { vi } from "vitest";
+
+const { mockSendMessage, mockRegenerate, mockUseChat } = vi.hoisted(() => ({
+  mockSendMessage: vi.fn().mockResolvedValue(undefined),
+  mockRegenerate: vi.fn().mockResolvedValue(undefined),
+  mockUseChat: vi.fn(),
+}));
+
+vi.mock("@ai-sdk/react", () => ({
+  useChat: mockUseChat,
+}));
+
+vi.mock("ai", () => ({
+  TextStreamChatTransport: class {},
+}));
+
+import { AssistantModel, AssistantTemperature } from "@/client/types/assistant";
+import { useChatSetup } from "./useChatSetup";
+
+const INITIAL_MESSAGES = [
+  {
+    id: "initial-message",
+    role: "assistant" as const,
+    parts: [
+      {
+        type: "text" as const,
+        text: "Hi, I am a chat bot. How can I help you today?",
+      },
+    ],
+  },
+];
+
+const WITH_USER_MESSAGE = [
+  ...INITIAL_MESSAGES,
+  {
+    id: "u1",
+    role: "user" as const,
+    parts: [{ type: "text" as const, text: "Hi" }],
+  },
+];
+
+function setupMockChat(
+  overrides: Partial<{
+    messages: unknown[];
+    status: string;
+  }> = {},
+) {
+  mockUseChat.mockReturnValue({
+    messages: INITIAL_MESSAGES,
+    sendMessage: mockSendMessage,
+    regenerate: mockRegenerate,
+    error: undefined,
+    status: "idle",
+    ...overrides,
+  });
+}
+
+describe("useChatSetup", () => {
+  beforeEach(() => {
+    setupMockChat();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns messages from useChat", () => {
+    const { result } = renderHook(() =>
+      useChatSetup(AssistantModel.FULL, AssistantTemperature.BALANCED),
+    );
+    expect(result.current.messages).toEqual(INITIAL_MESSAGES);
+  });
+
+  test("assistantIsLoading is true when status is submitted", () => {
+    setupMockChat({ status: "submitted" });
+    const { result } = renderHook(() =>
+      useChatSetup(AssistantModel.FULL, AssistantTemperature.BALANCED),
+    );
+    expect(result.current.assistantIsLoading).toBe(true);
+  });
+
+  test("assistantIsLoading is true when status is streaming", () => {
+    setupMockChat({ status: "streaming" });
+    const { result } = renderHook(() =>
+      useChatSetup(AssistantModel.FULL, AssistantTemperature.BALANCED),
+    );
+    expect(result.current.assistantIsLoading).toBe(true);
+  });
+
+  test("assistantIsLoading is false when status is idle", () => {
+    const { result } = renderHook(() =>
+      useChatSetup(AssistantModel.FULL, AssistantTemperature.BALANCED),
+    );
+    expect(result.current.assistantIsLoading).toBe(false);
+  });
+
+  test("hasUserMessage is false with only the initial assistant message", () => {
+    const { result } = renderHook(() =>
+      useChatSetup(AssistantModel.FULL, AssistantTemperature.BALANCED),
+    );
+    expect(result.current.hasUserMessage).toBe(false);
+  });
+
+  test("hasUserMessage is true when a user message is present", () => {
+    setupMockChat({ messages: WITH_USER_MESSAGE });
+    const { result } = renderHook(() =>
+      useChatSetup(AssistantModel.FULL, AssistantTemperature.BALANCED),
+    );
+    expect(result.current.hasUserMessage).toBe(true);
+  });
+
+  test("handleSendMessage calls sendMessage with text and model/temperature body", async () => {
+    const { result } = renderHook(() =>
+      useChatSetup(AssistantModel.FULL, AssistantTemperature.BALANCED),
+    );
+    await result.current.handleSendMessage("hello");
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      { text: "hello" },
+      {
+        body: {
+          model: AssistantModel.FULL,
+          temperature: AssistantTemperature.BALANCED,
+        },
+      },
+    );
+  });
+
+  test("handleRegenerateResponse calls regenerate when user message exists", async () => {
+    setupMockChat({ messages: WITH_USER_MESSAGE });
+    const { result } = renderHook(() =>
+      useChatSetup(AssistantModel.FULL, AssistantTemperature.BALANCED),
+    );
+    await result.current.handleRegenerateResponse();
+    expect(mockRegenerate).toHaveBeenCalledWith({
+      body: {
+        model: AssistantModel.FULL,
+        temperature: AssistantTemperature.BALANCED,
+      },
+    });
+  });
+
+  test("handleRegenerateResponse does not call regenerate without user messages", async () => {
+    const { result } = renderHook(() =>
+      useChatSetup(AssistantModel.FULL, AssistantTemperature.BALANCED),
+    );
+    await result.current.handleRegenerateResponse();
+    expect(mockRegenerate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/client/useChatSetup.ts
+++ b/frontend/client/useChatSetup.ts
@@ -1,0 +1,46 @@
+import { useChat } from "@ai-sdk/react";
+import { TextStreamChatTransport } from "ai";
+import { useMemo } from "react";
+import { CHAT_API_URL, INITIAL_MESSAGES } from "@/client/chatConstants";
+import type {
+  AssistantModel,
+  AssistantTemperature,
+} from "@/client/types/assistant";
+
+function useChatSetup(
+  model: AssistantModel,
+  temperature: AssistantTemperature,
+) {
+  const transport = useMemo(
+    () => new TextStreamChatTransport({ api: CHAT_API_URL }),
+    [],
+  );
+  const { messages, sendMessage, regenerate, error, status } = useChat({
+    messages: INITIAL_MESSAGES,
+    transport,
+    experimental_throttle: 50,
+  });
+  const assistantIsLoading = status === "submitted" || status === "streaming";
+  const hasUserMessage = messages.some((message) => message.role === "user");
+
+  const handleSendMessage = async (message: string) => {
+    await sendMessage({ text: message }, { body: { model, temperature } });
+  };
+
+  const handleRegenerateResponse = async () => {
+    if (hasUserMessage) {
+      await regenerate({ body: { model, temperature } });
+    }
+  };
+
+  return {
+    messages,
+    assistantIsLoading,
+    hasUserMessage,
+    error,
+    handleSendMessage,
+    handleRegenerateResponse,
+  };
+}
+
+export { useChatSetup };

--- a/frontend/client/useDarkMode.test.tsx
+++ b/frontend/client/useDarkMode.test.tsx
@@ -1,0 +1,115 @@
+import { act, renderHook } from "@testing-library/react";
+import { vi } from "vitest";
+import { useDarkMode } from "./useDarkMode";
+
+class MockMediaQueryList extends EventTarget implements MediaQueryList {
+  readonly matches: boolean;
+  readonly media: string;
+  onchange:
+    | ((this: MediaQueryList, ev: MediaQueryListEvent) => unknown)
+    | null = null;
+
+  constructor(matches: boolean, media: string) {
+    super();
+    this.matches = matches;
+    this.media = media;
+  }
+
+  addListener(): void {}
+  removeListener(): void {}
+}
+
+function mockMatchMedia(prefersDark: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    (query: string): MediaQueryList =>
+      new MockMediaQueryList(
+        prefersDark && query === "(prefers-color-scheme: dark)",
+        query,
+      ),
+  );
+}
+
+describe("useDarkMode", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("initializes to dark mode when system prefers dark", () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useDarkMode());
+    expect(result.current.darkMode).toBe(true);
+  });
+
+  test("initializes to light mode when system prefers light", () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useDarkMode());
+    expect(result.current.darkMode).toBe(false);
+  });
+
+  test("toggleDarkMode flips dark to light", () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useDarkMode());
+    act(() => result.current.toggleDarkMode());
+    expect(result.current.darkMode).toBe(false);
+  });
+
+  test("toggleDarkMode flips light to dark", () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useDarkMode());
+    act(() => result.current.toggleDarkMode());
+    expect(result.current.darkMode).toBe(true);
+  });
+
+  test("syncs colorScheme and theme-color meta to dark", () => {
+    mockMatchMedia(true);
+    const meta = document.createElement("meta");
+    meta.name = "theme-color";
+    document.head.append(meta);
+
+    renderHook(() => useDarkMode());
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+    expect(meta.content).toBe("#121212");
+
+    meta.remove();
+  });
+
+  test("syncs colorScheme and theme-color meta to light", () => {
+    mockMatchMedia(false);
+    const meta = document.createElement("meta");
+    meta.name = "theme-color";
+    document.head.append(meta);
+
+    renderHook(() => useDarkMode());
+    expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(meta.content).toBe("#ffffff");
+
+    meta.remove();
+  });
+
+  test("syncs browser chrome metadata when toggled from dark to light", () => {
+    mockMatchMedia(true);
+    const meta = document.createElement("meta");
+    meta.name = "theme-color";
+    document.head.append(meta);
+
+    const { result } = renderHook(() => useDarkMode());
+    act(() => result.current.toggleDarkMode());
+    expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(meta.content).toBe("#ffffff");
+
+    meta.remove();
+  });
+
+  test("theme palette mode is dark when darkMode is true", () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useDarkMode());
+    expect(result.current.theme.palette.mode).toBe("dark");
+  });
+
+  test("theme palette mode is light when darkMode is false", () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useDarkMode());
+    expect(result.current.theme.palette.mode).toBe("light");
+  });
+});

--- a/frontend/client/useDarkMode.ts
+++ b/frontend/client/useDarkMode.ts
@@ -1,0 +1,35 @@
+import { createTheme } from "@mui/material/styles";
+import { useEffect, useMemo, useState } from "react";
+
+const DARK_THEME_COLOR = "#121212";
+const LIGHT_THEME_COLOR = "#ffffff";
+
+function syncBrowserTheme(darkMode: boolean) {
+  document.documentElement.style.colorScheme = darkMode ? "dark" : "light";
+  document
+    .querySelector<HTMLMetaElement>('meta[name="theme-color"]')
+    ?.setAttribute("content", darkMode ? DARK_THEME_COLOR : LIGHT_THEME_COLOR);
+}
+
+function useDarkMode() {
+  const [darkMode, setDarkMode] = useState(() =>
+    typeof window !== "undefined" && typeof window.matchMedia === "function"
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+      : false,
+  );
+
+  useEffect(() => {
+    syncBrowserTheme(darkMode);
+  }, [darkMode]);
+
+  const theme = useMemo(
+    () => createTheme({ palette: { mode: darkMode ? "dark" : "light" } }),
+    [darkMode],
+  );
+
+  const toggleDarkMode = () => setDarkMode((prev) => !prev);
+
+  return { darkMode, theme, toggleDarkMode };
+}
+
+export { useDarkMode };

--- a/frontend/components/ControlPanel.test.tsx
+++ b/frontend/components/ControlPanel.test.tsx
@@ -1,0 +1,171 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { AssistantModel, AssistantTemperature } from "@/client/types/assistant";
+
+vi.mock("@/components/messages/ChatInput", () => ({
+  default: ({
+    onSendMessage,
+    disabled,
+  }: {
+    onSendMessage: (msg: string) => Promise<void>;
+    disabled: boolean;
+  }) => (
+    <button
+      type="button"
+      data-testid="chat-input-send"
+      data-disabled={String(disabled)}
+      onClick={() => void onSendMessage("test message")}
+    >
+      Send
+    </button>
+  ),
+}));
+
+vi.mock("@/components/parameters/DropdownParameter", () => ({
+  default: ({
+    onChange,
+    ariaLabel,
+    options,
+    value,
+  }: {
+    onChange: (v: string) => void;
+    ariaLabel: string;
+    options: Array<{ value: string; label: string }>;
+    value: string;
+  }) => (
+    <select
+      aria-label={ariaLabel}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {options.map((o) => (
+        <option
+          key={o.value}
+          value={o.value}
+        >
+          {o.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+import ControlPanel from "./ControlPanel";
+
+const DEFAULT_PROPS = {
+  model: AssistantModel.FULL,
+  setModel: vi.fn(),
+  temperature: AssistantTemperature.BALANCED,
+  setTemperature: vi.fn(),
+  onRegenerate: vi.fn(),
+  canRegenerate: true,
+  darkMode: false,
+  onToggleDarkMode: vi.fn(),
+  disabled: false,
+  onSendMessage: vi.fn().mockResolvedValue(undefined),
+};
+
+describe("ControlPanel", () => {
+  test("renders model dropdown", () => {
+    render(<ControlPanel {...DEFAULT_PROPS} />);
+    expect(
+      screen.getByLabelText(/Select assistant model/i),
+    ).toBeInTheDocument();
+  });
+
+  test("renders temperature dropdown", () => {
+    render(<ControlPanel {...DEFAULT_PROPS} />);
+    expect(
+      screen.getByLabelText(/Select assistant temperature/i),
+    ).toBeInTheDocument();
+  });
+
+  test("regenerate button is enabled when canRegenerate is true and not disabled", () => {
+    render(
+      <ControlPanel
+        {...DEFAULT_PROPS}
+        canRegenerate={true}
+        disabled={false}
+      />,
+    );
+    expect(screen.getByLabelText("Regenerate response")).not.toBeDisabled();
+  });
+
+  test("regenerate button is disabled when canRegenerate is false", () => {
+    render(
+      <ControlPanel
+        {...DEFAULT_PROPS}
+        canRegenerate={false}
+      />,
+    );
+    expect(screen.getByLabelText("Regenerate response")).toBeDisabled();
+  });
+
+  test("regenerate button is disabled when disabled is true", () => {
+    render(
+      <ControlPanel
+        {...DEFAULT_PROPS}
+        disabled={true}
+      />,
+    );
+    expect(screen.getByLabelText("Regenerate response")).toBeDisabled();
+  });
+
+  test("clicking regenerate calls onRegenerate", () => {
+    const onRegenerate = vi.fn();
+    render(
+      <ControlPanel
+        {...DEFAULT_PROPS}
+        onRegenerate={onRegenerate}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Regenerate response"));
+    expect(onRegenerate).toHaveBeenCalledTimes(1);
+  });
+
+  test("shows dark mode icon when darkMode is false", () => {
+    render(
+      <ControlPanel
+        {...DEFAULT_PROPS}
+        darkMode={false}
+      />,
+    );
+    expect(screen.getByLabelText("Switch to dark mode")).toBeInTheDocument();
+  });
+
+  test("shows light mode icon when darkMode is true", () => {
+    render(
+      <ControlPanel
+        {...DEFAULT_PROPS}
+        darkMode={true}
+      />,
+    );
+    expect(screen.getByLabelText("Switch to light mode")).toBeInTheDocument();
+  });
+
+  test("clicking dark mode toggle calls onToggleDarkMode", () => {
+    const onToggleDarkMode = vi.fn();
+    render(
+      <ControlPanel
+        {...DEFAULT_PROPS}
+        darkMode={false}
+        onToggleDarkMode={onToggleDarkMode}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Switch to dark mode"));
+    expect(onToggleDarkMode).toHaveBeenCalledTimes(1);
+  });
+
+  test("ChatInput receives disabled prop", () => {
+    render(
+      <ControlPanel
+        {...DEFAULT_PROPS}
+        disabled={true}
+      />,
+    );
+    expect(screen.getByTestId("chat-input-send")).toHaveAttribute(
+      "data-disabled",
+      "true",
+    );
+  });
+});

--- a/frontend/components/ControlPanel.tsx
+++ b/frontend/components/ControlPanel.tsx
@@ -1,0 +1,128 @@
+import DarkModeIcon from "@mui/icons-material/DarkMode";
+import LightModeIcon from "@mui/icons-material/LightMode";
+import PsychologyIcon from "@mui/icons-material/Psychology";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import ThermostatIcon from "@mui/icons-material/Thermostat";
+import { Box, IconButton, Stack, Tooltip } from "@mui/material";
+import { getModelDisplay, getTemperatureDisplay } from "@/client/helpers";
+import { AssistantModel, AssistantTemperature } from "@/client/types/assistant";
+import ChatInput from "@/components/messages/ChatInput";
+import DropdownParameter from "@/components/parameters/DropdownParameter";
+
+const MODEL_OPTIONS = [
+  { value: AssistantModel.FULL, label: "GPT-4o" },
+  { value: AssistantModel.MINI, label: "GPT-4o Mini" },
+];
+
+const TEMPERATURE_OPTIONS = [
+  {
+    value: AssistantTemperature.DETERMINISTIC,
+    label: "0.2 - More Deterministic",
+  },
+  { value: AssistantTemperature.BALANCED, label: "0.7 - Balanced" },
+  { value: AssistantTemperature.CREATIVE, label: "0.9 - More Creative" },
+];
+
+interface DarkModeToggleProps {
+  darkMode: boolean;
+  onToggle: () => void;
+}
+
+function DarkModeToggle({ darkMode, onToggle }: DarkModeToggleProps) {
+  return (
+    <Tooltip title={darkMode ? "Switch to Light Mode" : "Switch to Dark Mode"}>
+      <IconButton
+        onClick={onToggle}
+        aria-label={darkMode ? "Switch to light mode" : "Switch to dark mode"}
+      >
+        {darkMode ? <LightModeIcon /> : <DarkModeIcon />}
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+interface ControlPanelProps {
+  model: AssistantModel;
+  setModel: (m: AssistantModel) => void;
+  temperature: AssistantTemperature;
+  setTemperature: (t: AssistantTemperature) => void;
+  onRegenerate: () => void;
+  canRegenerate: boolean;
+  darkMode: boolean;
+  onToggleDarkMode: () => void;
+  disabled: boolean;
+  onSendMessage: (message: string) => Promise<void>;
+}
+
+function ControlPanel({
+  model,
+  setModel,
+  temperature,
+  setTemperature,
+  onRegenerate,
+  canRegenerate,
+  darkMode,
+  onToggleDarkMode,
+  disabled,
+  onSendMessage,
+}: ControlPanelProps) {
+  return (
+    <Box sx={{ p: 2 }}>
+      <Stack
+        direction="row"
+        spacing={2}
+        sx={{ mb: 2 }}
+      >
+        <DropdownParameter
+          value={model}
+          onChange={setModel}
+          icon={<PsychologyIcon />}
+          tooltipTitle={
+            <>
+              Choose Assistant Model
+              <br />
+              (Current: {getModelDisplay(model)})
+            </>
+          }
+          ariaLabel={`Select assistant model. Current model: ${getModelDisplay(model)}`}
+          options={MODEL_OPTIONS}
+        />
+        <DropdownParameter
+          value={temperature}
+          onChange={setTemperature}
+          icon={<ThermostatIcon />}
+          tooltipTitle={
+            <>
+              Choose Temperature
+              <br />
+              (Current: {getTemperatureDisplay(temperature)})
+            </>
+          }
+          ariaLabel={`Select assistant temperature. Current temperature: ${getTemperatureDisplay(temperature)}`}
+          options={TEMPERATURE_OPTIONS}
+        />
+        <Tooltip title="Regenerate Response">
+          <span>
+            <IconButton
+              disabled={disabled || !canRegenerate}
+              onClick={onRegenerate}
+              aria-label="Regenerate response"
+            >
+              <RefreshIcon />
+            </IconButton>
+          </span>
+        </Tooltip>
+        <DarkModeToggle
+          darkMode={darkMode}
+          onToggle={onToggleDarkMode}
+        />
+      </Stack>
+      <ChatInput
+        onSendMessage={onSendMessage}
+        disabled={disabled}
+      />
+    </Box>
+  );
+}
+
+export default ControlPanel;

--- a/frontend/components/messages/MessageList.test.tsx
+++ b/frontend/components/messages/MessageList.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+vi.mock("@/components/messages/AssistantMessage", () => ({
+  default: ({
+    content,
+    isFirstMessage,
+  }: {
+    content: string;
+    isFirstMessage: boolean;
+  }) => (
+    <div
+      data-testid="assistant-message"
+      data-first-message={String(isFirstMessage)}
+    >
+      {content}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/messages/UserMessage", () => ({
+  default: ({ content }: { content: string }) => (
+    <div data-testid="user-message">{content}</div>
+  ),
+}));
+
+import MessageList from "./MessageList";
+
+const INITIAL_MESSAGE = {
+  id: "initial-message",
+  role: "assistant" as const,
+  parts: [{ type: "text" as const, text: "Hi, I am a chat bot." }],
+};
+
+describe("MessageList", () => {
+  test("renders initial assistant message marked as first message", () => {
+    render(
+      <MessageList
+        messages={[INITIAL_MESSAGE]}
+        assistantIsLoading={false}
+        error={undefined}
+      />,
+    );
+    const msg = screen.getByTestId("assistant-message");
+    expect(msg).toHaveTextContent("Hi, I am a chat bot.");
+    expect(msg).toHaveAttribute("data-first-message", "true");
+  });
+
+  test("non-initial assistant messages have isFirstMessage false", () => {
+    render(
+      <MessageList
+        messages={[
+          INITIAL_MESSAGE,
+          {
+            id: "a2",
+            role: "assistant" as const,
+            parts: [{ type: "text" as const, text: "Reply" }],
+          },
+        ]}
+        assistantIsLoading={false}
+        error={undefined}
+      />,
+    );
+    const msgs = screen.getAllByTestId("assistant-message");
+    expect(msgs[0]).toHaveAttribute("data-first-message", "true");
+    expect(msgs[1]).toHaveAttribute("data-first-message", "false");
+  });
+
+  test("renders user messages", () => {
+    render(
+      <MessageList
+        messages={[
+          INITIAL_MESSAGE,
+          {
+            id: "u1",
+            role: "user" as const,
+            parts: [{ type: "text" as const, text: "Hello bot" }],
+          },
+        ]}
+        assistantIsLoading={false}
+        error={undefined}
+      />,
+    );
+    expect(screen.getByTestId("user-message")).toHaveTextContent("Hello bot");
+  });
+
+  test("shows loading indicator when assistantIsLoading is true", () => {
+    render(
+      <MessageList
+        messages={[INITIAL_MESSAGE]}
+        assistantIsLoading={true}
+        error={undefined}
+      />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("Generating…");
+  });
+
+  test("hides loading indicator when assistantIsLoading is false", () => {
+    render(
+      <MessageList
+        messages={[INITIAL_MESSAGE]}
+        assistantIsLoading={false}
+        error={undefined}
+      />,
+    );
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  test("shows error alert when error is present", () => {
+    render(
+      <MessageList
+        messages={[INITIAL_MESSAGE]}
+        assistantIsLoading={false}
+        error={new Error("Network error")}
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Something went wrong. Try sending your message again. Details: Network error",
+    );
+  });
+
+  test("non-text message parts yield empty string", () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: "a1",
+            role: "assistant" as const,
+            parts: [{ type: "step-start" }],
+          },
+        ]}
+        assistantIsLoading={false}
+        error={undefined}
+      />,
+    );
+    const msg = screen.getByTestId("assistant-message");
+    expect(msg).toHaveTextContent("");
+  });
+});

--- a/frontend/components/messages/MessageList.tsx
+++ b/frontend/components/messages/MessageList.tsx
@@ -1,0 +1,71 @@
+import type { UIMessage } from "@ai-sdk/react";
+import { Alert, Box, CircularProgress, Stack, Typography } from "@mui/material";
+import { INITIAL_MESSAGE_ID } from "@/client/chatConstants";
+import AssistantMessage from "@/components/messages/AssistantMessage";
+import UserMessage from "@/components/messages/UserMessage";
+
+function renderMessage(message: UIMessage) {
+  const content = message.parts
+    .map((part) => (part.type === "text" ? part.text : ""))
+    .join("");
+
+  return message.role === "user" ? (
+    <UserMessage
+      key={message.id}
+      content={content}
+    />
+  ) : (
+    <AssistantMessage
+      key={message.id}
+      content={content}
+      isFirstMessage={message.id === INITIAL_MESSAGE_ID}
+    />
+  );
+}
+
+interface MessageListProps {
+  messages: UIMessage[];
+  assistantIsLoading: boolean;
+  error: Error | undefined;
+}
+
+function MessageList({
+  messages,
+  assistantIsLoading,
+  error,
+}: MessageListProps) {
+  return (
+    <Box
+      component="section"
+      aria-label="Chat conversation"
+      sx={{ flexGrow: 1, overflowY: "auto", p: 2 }}
+    >
+      <Stack spacing={2}>
+        {messages.map(renderMessage)}
+        {assistantIsLoading && (
+          <Stack
+            aria-live="polite"
+            direction="row"
+            role="status"
+            spacing={1}
+            sx={{ alignItems: "center" }}
+          >
+            <CircularProgress
+              aria-hidden={true}
+              size={20}
+            />
+            <Typography variant="body2">Generating…</Typography>
+          </Stack>
+        )}
+        {error && (
+          <Alert severity="error">
+            Something went wrong. Try sending your message again. Details:{" "}
+            {error.message}
+          </Alert>
+        )}
+      </Stack>
+    </Box>
+  );
+}
+
+export default MessageList;


### PR DESCRIPTION
## Summary

- **Frontend decomposition**: Extracted `MessageList`, `ControlPanel`, `useDarkMode`, and `useChatSetup` from `page.tsx` into focused modules. `page.tsx` is now ~70 lines of pure composition. Each extracted file has its own test suite (79 tests total across 13 files, all coverage thresholds met).
- **Dependabot coverage**: Added `npm` (pnpm) and `uv` entries to `.github/dependabot.yaml` so runtime dependencies receive weekly automated update PRs alongside GitHub Actions.
- **Eval doc cleanup**: Removed sections from `code-quality-evals/` that are now addressed — frontend decomposition, dependency update coverage (this PR), configuration fail-fast (PR #76), dark mode default and WCAG target documentation (PR #75).

## New files

| File | Role |
|------|------|
| `frontend/client/chatConstants.ts` | Shared constants: `INITIAL_MESSAGE_ID`, `CHAT_API_URL`, `INITIAL_MESSAGES` |
| `frontend/client/useDarkMode.ts` | Dark mode state, theme memoization, browser sync |
| `frontend/client/useChatSetup.ts` | Chat transport, `useChat` wiring, send/regenerate handlers |
| `frontend/components/messages/MessageList.tsx` | Message list with loading indicator and error alert |
| `frontend/components/ControlPanel.tsx` | Dropdowns, regenerate button, dark mode toggle, chat input |

## Test plan

- [x] `make qa` passes (format, lint, type-check, 79 tests, 100% backend coverage, ≥90% frontend coverage, security scan)
- [x] TypeScript 100% type coverage maintained
- [x] ls-lint file naming conventions respected