### PR TITLE
feat(security): add rate limiting and request-size limits to chat endpoint

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,7 +1,8 @@
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
-from pydantic import Field, model_validator
+from limits import parse
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 if TYPE_CHECKING:
@@ -23,6 +24,16 @@ class Settings(BaseSettings):
         env_file=".env",
         extra="ignore",
     )
+
+    @field_validator("chat_rate_limit", mode="after")
+    @classmethod
+    def validate_rate_limit(cls, v: str) -> str:
+        try:
+            parse(v)
+        except ValueError as e:
+            msg: str = f"Invalid rate limit format: {v}"
+            raise ValueError(msg) from e
+        return v
 
     @model_validator(mode="after")
     def validate_azure_settings(self) -> Settings:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
         default_factory=lambda: ["http://localhost:3000"],
         alias="CORS_ALLOWED_ORIGINS",
     )
+    chat_rate_limit: str = Field(default="10/minute", alias="CHAT_RATE_LIMIT")
     testing: bool = Field(default=False, alias="TESTING")
 
     model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Annotated, Literal
 
 import openai
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 from loguru import logger
@@ -45,7 +45,7 @@ app.add_middleware(
 @app.exception_handler(RateLimitExceeded)
 def rate_limit_handler(_request: Request, _exc: RateLimitExceeded) -> JSONResponse:
     return JSONResponse(
-        status_code=429,
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
         content={"detail": "Rate limit exceeded. Please try again later."},
     )
 
@@ -128,7 +128,7 @@ def _to_openai_messages(messages: list[UIMessage]) -> list[ChatMessage]:
 
     if not openai_messages:
         raise HTTPException(
-            status_code=400,
+            status_code=status.HTTP_400_BAD_REQUEST,
             detail="At least one text message is required.",
         )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,14 @@
 from typing import TYPE_CHECKING, Annotated, Literal
 
 import openai
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from loguru import logger
 from pydantic import BaseModel, Field, model_validator
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
 
 from app.azure_client import ChatMessage, stream_azure_openai_response
 from app.config import get_settings
@@ -16,13 +19,20 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from app.config import Settings
 
+_MAX_MESSAGES = 50
+_MAX_MESSAGE_CHARS = 32_000
+
 settings: Settings = get_settings()
+
+limiter: Limiter = Limiter(key_func=get_remote_address)
 
 app: FastAPI = FastAPI(
     title="chatbot-template backend",
     description="Streaming backend API for the chatbot template.",
     version="1.0.0",
 )
+
+app.state.limiter = limiter
 
 app.add_middleware(
     CORSMiddleware,
@@ -32,9 +42,17 @@ app.add_middleware(
 )
 
 
+@app.exception_handler(RateLimitExceeded)
+def rate_limit_handler(_request: Request, _exc: RateLimitExceeded) -> JSONResponse:
+    return JSONResponse(
+        status_code=429,
+        content={"detail": "Rate limit exceeded. Please try again later."},
+    )
+
+
 class TextPart(BaseModel):
     type: Literal["text"]
-    text: str
+    text: Annotated[str, Field(max_length=_MAX_MESSAGE_CHARS)]
 
 
 def _parse_message_text(content: str | None, parts: list[TextPart]) -> str:
@@ -45,7 +63,7 @@ def _parse_message_text(content: str | None, parts: list[TextPart]) -> str:
 
 class UIMessage(BaseModel):
     role: OpenAIMessageRole
-    content: str | None = None
+    content: str | None = Field(default=None, max_length=_MAX_MESSAGE_CHARS)
     parts: list[TextPart] = Field(default_factory=list)
 
     @model_validator(mode="after")
@@ -61,7 +79,7 @@ class UIMessage(BaseModel):
 
 
 class ChatRequest(BaseModel):
-    messages: Annotated[list[UIMessage], Field(min_length=1)]
+    messages: Annotated[list[UIMessage], Field(min_length=1, max_length=_MAX_MESSAGES)]
     model: AssistantModel = AssistantModel.FULL
     temperature: AssistantTemperature = AssistantTemperature.BALANCED
 
@@ -81,20 +99,21 @@ def health() -> dict[str, str]:
         },
     },
 )
-def chat(request: ChatRequest) -> StreamingResponse:
-    messages: list[ChatMessage] = _to_openai_messages(request.messages)
+@limiter.limit(lambda: settings.chat_rate_limit)
+def chat(request: Request, body: ChatRequest) -> StreamingResponse:
+    messages: list[ChatMessage] = _to_openai_messages(body.messages)
     logger.debug(
         "Received chat stream request with {} messages, model={}, temperature={}",
         len(messages),
-        request.model.value,
-        request.temperature.name,
+        body.model.value,
+        body.temperature.name,
     )
 
     return StreamingResponse(
         _stream_chat(
             messages=messages,
-            model=request.model,
-            temperature=request.temperature,
+            model=body.model,
+            temperature=body.temperature,
         ),
         media_type="text/plain; charset=utf-8",
     )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "loguru>=0.7.3",
     "openai>=2.34.0",
     "pydantic-settings>=2.14.0",
+    "slowapi>=0.1.9",
 ]
 
 [dependency-groups]
@@ -50,6 +51,10 @@ max-returns = 3
 max-statements = 20
 
 [tool.ruff.lint.per-file-ignores]
+"app/main.py" = [
+    # slowapi requires the endpoint parameter named `request`; it never appears in the body
+    "ARG001",
+]
 "test_*.py" = [
     # tests can have asserts
     "S101",
@@ -64,6 +69,8 @@ max-statements = 20
     "PLC1901",
     # long expected-value strings in parametrize are unavoidable
     "E501",
+    # tests must reach private storage to reset rate-limit counters between runs
+    "SLF001",
 ]
 
 [tool.ruff.format]
@@ -91,5 +98,9 @@ addopts = [
     "-ra",
 ]
 xfail_strict = true
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    # slowapi 0.1.9 calls asyncio.iscoroutinefunction, deprecated in Python 3.14
+    "ignore:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning",
+]
 python_files = ["test_*.py", "test-*.py", "tests.py", "test.py"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -69,8 +69,6 @@ max-statements = 20
     "PLC1901",
     # long expected-value strings in parametrize are unavoidable
     "E501",
-    # tests must reach private storage to reset rate-limit counters between runs
-    "SLF001",
 ]
 
 [tool.ruff.format]

--- a/backend/tests/test_azure_client.py
+++ b/backend/tests/test_azure_client.py
@@ -40,6 +40,16 @@ def create_chunk(content: str | None) -> object:
 
 
 @pytest.fixture
+def prompt_messages() -> list[dict[str, str]]:
+    return [
+        {
+            "role": "user",
+            "content": "Test prompt",
+        },
+    ]
+
+
+@pytest.fixture
 def mock_azure_client(monkeypatch: pytest.MonkeyPatch) -> MockAzureClient:
     mock_client: MockAzureClient = MockAzureClient()
     get_azure_openai_client.cache_clear()
@@ -58,6 +68,7 @@ def mock_azure_client(monkeypatch: pytest.MonkeyPatch) -> MockAzureClient:
 )
 def test_stream_successful_response(
     mock_azure_client: MockAzureClient,
+    prompt_messages: list[dict[str, str]],
     model: AssistantModel,
     temperature: AssistantTemperature,
     expected_model: str,
@@ -71,12 +82,7 @@ def test_stream_successful_response(
 
     response: list[str] = list(
         stream_azure_openai_response(
-            messages=[
-                {
-                    "role": "user",
-                    "content": "Test prompt",
-                },
-            ],
+            messages=prompt_messages,
             model=model,
             temperature=temperature,
         ),
@@ -87,12 +93,7 @@ def test_stream_successful_response(
         {
             "model": expected_model,
             "temperature": expected_temp,
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "Test prompt",
-                },
-            ],
+            "messages": prompt_messages,
             "stream": True,
         },
     ]
@@ -108,6 +109,7 @@ def test_stream_successful_response(
 )
 def test_api_exception(
     mock_azure_client: MockAzureClient,
+    prompt_messages: list[dict[str, str]],
     exc_class: type[Exception],
     message: str,
 ) -> None:
@@ -116,12 +118,7 @@ def test_api_exception(
     with pytest.raises(exc_class, match=message):
         list(
             stream_azure_openai_response(
-                messages=[
-                    {
-                        "role": "user",
-                        "content": "Test prompt",
-                    },
-                ],
+                messages=prompt_messages,
                 model=AssistantModel.FULL,
                 temperature=AssistantTemperature.BALANCED,
             ),
@@ -162,6 +159,7 @@ def _make_response(status_code: int) -> httpx.Response:
 )
 def test_openai_api_exceptions_are_reraised(
     mock_azure_client: MockAzureClient,
+    prompt_messages: list[dict[str, str]],
     exc: openai.APIError,
 ) -> None:
     mock_azure_client.chat.completions.side_effect = exc
@@ -169,12 +167,7 @@ def test_openai_api_exceptions_are_reraised(
     with pytest.raises(type(exc)):
         list(
             stream_azure_openai_response(
-                messages=[
-                    {
-                        "role": "user",
-                        "content": "Test prompt",
-                    },
-                ],
+                messages=prompt_messages,
                 model=AssistantModel.FULL,
                 temperature=AssistantTemperature.BALANCED,
             ),

--- a/backend/tests/test_azure_client.py
+++ b/backend/tests/test_azure_client.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 import openai
 import pytest
+from fastapi import status
 
 from app.azure_client import get_azure_openai_client, stream_azure_openai_response
 from app.entities import AssistantModel, AssistantTemperature
@@ -70,7 +71,12 @@ def test_stream_successful_response(
 
     response: list[str] = list(
         stream_azure_openai_response(
-            messages=[{"role": "user", "content": "Test prompt"}],
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Test prompt",
+                },
+            ],
             model=model,
             temperature=temperature,
         ),
@@ -81,7 +87,12 @@ def test_stream_successful_response(
         {
             "model": expected_model,
             "temperature": expected_temp,
-            "messages": [{"role": "user", "content": "Test prompt"}],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Test prompt",
+                },
+            ],
             "stream": True,
         },
     ]
@@ -105,7 +116,12 @@ def test_api_exception(
     with pytest.raises(exc_class, match=message):
         list(
             stream_azure_openai_response(
-                messages=[{"role": "user", "content": "Test prompt"}],
+                messages=[
+                    {
+                        "role": "user",
+                        "content": "Test prompt",
+                    },
+                ],
                 model=AssistantModel.FULL,
                 temperature=AssistantTemperature.BALANCED,
             ),
@@ -125,12 +141,12 @@ def _make_response(status_code: int) -> httpx.Response:
     [
         openai.AuthenticationError(
             "auth failed",
-            response=_make_response(401),
+            response=_make_response(status.HTTP_401_UNAUTHORIZED),
             body=None,
         ),
         openai.RateLimitError(
             "rate limited",
-            response=_make_response(429),
+            response=_make_response(status.HTTP_429_TOO_MANY_REQUESTS),
             body=None,
         ),
         openai.APIConnectionError(
@@ -139,7 +155,7 @@ def _make_response(status_code: int) -> httpx.Response:
         ),
         openai.InternalServerError(
             "server error",
-            response=_make_response(500),
+            response=_make_response(status.HTTP_500_INTERNAL_SERVER_ERROR),
             body=None,
         ),
     ],
@@ -153,7 +169,12 @@ def test_openai_api_exceptions_are_reraised(
     with pytest.raises(type(exc)):
         list(
             stream_azure_openai_response(
-                messages=[{"role": "user", "content": "Test prompt"}],
+                messages=[
+                    {
+                        "role": "user",
+                        "content": "Test prompt",
+                    },
+                ],
                 model=AssistantModel.FULL,
                 temperature=AssistantTemperature.BALANCED,
             ),
@@ -195,7 +216,7 @@ def test_openai_api_error_mid_stream_is_reraised(
 ) -> None:
     mid_stream_exc: openai.InternalServerError = openai.InternalServerError(
         "mid-stream failure",
-        response=_make_response(500),
+        response=_make_response(status.HTTP_500_INTERNAL_SERVER_ERROR),
         body=None,
     )
 
@@ -208,7 +229,12 @@ def test_openai_api_error_mid_stream_is_reraised(
     with pytest.raises(openai.InternalServerError, match="mid-stream failure"):
         list(
             stream_azure_openai_response(
-                messages=[{"role": "user", "content": "Test"}],
+                messages=[
+                    {
+                        "role": "user",
+                        "content": "Test",
+                    },
+                ],
                 model=AssistantModel.FULL,
                 temperature=AssistantTemperature.BALANCED,
             ),
@@ -227,7 +253,12 @@ def test_stream_skips_chunks_with_empty_choices(
 
     result: list[str] = list(
         stream_azure_openai_response(
-            messages=[{"role": "user", "content": "Test"}],
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Test",
+                },
+            ],
             model=AssistantModel.FULL,
             temperature=AssistantTemperature.BALANCED,
         ),

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -85,6 +85,11 @@ def test_settings_default_chat_rate_limit() -> None:
     assert s.chat_rate_limit == "10/minute"
 
 
+def test_settings_raises_on_invalid_chat_rate_limit() -> None:
+    with pytest.raises(ValueError, match="Invalid rate limit format: 10/minx"):
+        Settings(TESTING=True, CHAT_RATE_LIMIT="10/minx")
+
+
 def test_get_settings_returns_cached_instance() -> None:
     get_settings.cache_clear()
     first: Settings = get_settings()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -80,6 +80,11 @@ def test_settings_testing_mode_allows_empty_azure_credentials() -> None:
     assert s.testing is True
 
 
+def test_settings_default_chat_rate_limit() -> None:
+    s: Settings = Settings(TESTING=True)
+    assert s.chat_rate_limit == "10/minute"
+
+
 def test_get_settings_returns_cached_instance() -> None:
     get_settings.cache_clear()
     first: Settings = get_settings()

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -16,7 +16,34 @@ if TYPE_CHECKING:  # pragma: no cover
     from httpx import Response
 
 
-def test_post_chat_stream_success(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+def raising_client() -> TestClient:
+    return TestClient(app, raise_server_exceptions=True)
+
+
+@pytest.fixture
+def hi_message() -> dict[str, object]:
+    return {
+        "role": "user",
+        "parts": [
+            {
+                "type": "text",
+                "text": "Hi",
+            },
+        ],
+    }
+
+
+def test_post_chat_stream_success(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+    hi_message: dict[str, object],
+) -> None:
     calls: list[dict[str, object]] = []
 
     def mock_stream(**kwargs: object) -> Iterator[str]:
@@ -26,21 +53,10 @@ def test_post_chat_stream_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr("app.main.stream_azure_openai_response", mock_stream)
 
-    client: TestClient = TestClient(app)
     response: Response = client.post(
         "/api/v1/chat",
         json={
-            "messages": [
-                {
-                    "role": "user",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": "Hi",
-                        },
-                    ],
-                },
-            ],
+            "messages": [hi_message],
             "model": "gpt-4o-mini",
             "temperature": "BALANCED",
         },
@@ -58,8 +74,7 @@ def test_post_chat_stream_success(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
 
 
-def test_post_chat_rejects_empty_messages() -> None:
-    client: TestClient = TestClient(app)
+def test_post_chat_rejects_empty_messages(client: TestClient) -> None:
     response: Response = client.post(
         "/api/v1/chat",
         json={
@@ -90,24 +105,15 @@ def test_post_chat_rejects_empty_messages() -> None:
     ],
 )
 def test_post_chat_rejects_invalid_model_or_temperature(
+    client: TestClient,
+    hi_message: dict[str, object],
     model: str,
     temperature: str,
 ) -> None:
-    client: TestClient = TestClient(app)
     response: Response = client.post(
         "/api/v1/chat",
         json={
-            "messages": [
-                {
-                    "role": "user",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": "Hi",
-                        },
-                    ],
-                },
-            ],
+            "messages": [hi_message],
             "model": model,
             "temperature": temperature,
         },
@@ -116,31 +122,19 @@ def test_post_chat_rejects_invalid_model_or_temperature(
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
-def test_post_chat_rejects_too_many_messages() -> None:
-    client: TestClient = TestClient(app)
+def test_post_chat_rejects_too_many_messages(
+    client: TestClient,
+    hi_message: dict[str, object],
+) -> None:
     response: Response = client.post(
         "/api/v1/chat",
-        json={
-            "messages": [
-                {
-                    "role": "user",
-                    "parts": [
-                        {
-                            "type": "text",
-                            "text": "Hi",
-                        },
-                    ],
-                },
-            ]
-            * 51,
-        },
+        json={"messages": [hi_message] * 51},
     )
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
-def test_post_chat_rejects_message_content_too_long() -> None:
-    client: TestClient = TestClient(app)
+def test_post_chat_rejects_message_content_too_long(client: TestClient) -> None:
     response: Response = client.post(
         "/api/v1/chat",
         json={
@@ -158,6 +152,8 @@ def test_post_chat_rejects_message_content_too_long() -> None:
 
 def test_chat_endpoint_rate_limits_after_threshold(
     monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+    hi_message: dict[str, object],
 ) -> None:
     def mock_stream(**_: object) -> Iterator[str]:
         yield "ok"
@@ -166,20 +162,7 @@ def test_chat_endpoint_rate_limits_after_threshold(
     monkeypatch.setattr(settings, "chat_rate_limit", "1/minute")
     limiter._storage.reset()
 
-    client: TestClient = TestClient(app)
-    payload: dict[str, object] = {
-        "messages": [
-            {
-                "role": "user",
-                "parts": [
-                    {
-                        "type": "text",
-                        "text": "Hi",
-                    },
-                ],
-            },
-        ],
-    }
+    payload: dict[str, object] = {"messages": [hi_message]}
 
     assert client.post("/api/v1/chat", json=payload).status_code == status.HTTP_200_OK
 
@@ -188,8 +171,7 @@ def test_chat_endpoint_rate_limits_after_threshold(
     assert response.json() == {"detail": "Rate limit exceeded. Please try again later."}
 
 
-def test_health() -> None:
-    client: TestClient = TestClient(app)
+def test_health(client: TestClient) -> None:
     response: Response = client.get("/health")
 
     assert response.status_code == status.HTTP_200_OK
@@ -225,6 +207,8 @@ def test_ui_message_rejects_empty_content_and_parts() -> None:
 
 def test_stream_chat_reraises_non_openai_exception(
     monkeypatch: pytest.MonkeyPatch,
+    raising_client: TestClient,
+    hi_message: dict[str, object],
 ) -> None:
     def mock_stream(**kwargs: object) -> None:
         msg: str = "Upstream failure"
@@ -232,23 +216,10 @@ def test_stream_chat_reraises_non_openai_exception(
 
     monkeypatch.setattr("app.main.stream_azure_openai_response", mock_stream)
 
-    client: TestClient = TestClient(app, raise_server_exceptions=True)
     with pytest.raises(RuntimeError, match="Upstream failure"):
-        client.post(
+        raising_client.post(
             "/api/v1/chat",
-            json={
-                "messages": [
-                    {
-                        "role": "user",
-                        "parts": [
-                            {
-                                "type": "text",
-                                "text": "Hi",
-                            },
-                        ],
-                    },
-                ],
-            },
+            json={"messages": [hi_message]},
         )
 
 
@@ -286,7 +257,9 @@ def _make_openai_response(status_code: int) -> httpx.Response:
 )
 def test_stream_chat_reraises_openai_api_errors(
     monkeypatch: pytest.MonkeyPatch,
+    raising_client: TestClient,
     exc: openai.APIError,
+    hi_message: dict[str, object],
 ) -> None:
     captured_exc: openai.APIError = exc
 
@@ -295,21 +268,8 @@ def test_stream_chat_reraises_openai_api_errors(
 
     monkeypatch.setattr("app.main.stream_azure_openai_response", mock_stream)
 
-    client: TestClient = TestClient(app, raise_server_exceptions=True)
     with pytest.raises(type(captured_exc)):
-        client.post(
+        raising_client.post(
             "/api/v1/chat",
-            json={
-                "messages": [
-                    {
-                        "role": "user",
-                        "parts": [
-                            {
-                                "type": "text",
-                                "text": "Hi",
-                            },
-                        ],
-                    },
-                ],
-            },
+            json={"messages": [hi_message]},
         )

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -16,6 +16,11 @@ if TYPE_CHECKING:  # pragma: no cover
     from httpx import Response
 
 
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter() -> None:
+    limiter._storage.reset()  # noqa: SLF001
+
+
 @pytest.fixture
 def client() -> TestClient:
     return TestClient(app)
@@ -160,7 +165,6 @@ def test_chat_endpoint_rate_limits_after_threshold(
 
     monkeypatch.setattr("app.main.stream_azure_openai_response", mock_stream)
     monkeypatch.setattr(settings, "chat_rate_limit", "1/minute")
-    limiter._storage.reset()
 
     payload: dict[str, object] = {"messages": [hi_message]}
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
 from app.entities import AssistantModel, AssistantTemperature, OpenAIMessageRole
-from app.main import TextPart, UIMessage, app
+from app.main import TextPart, UIMessage, app, limiter, settings
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterator
@@ -90,6 +90,53 @@ def test_post_chat_rejects_invalid_model_or_temperature(
     assert response.status_code == 422
 
 
+def test_post_chat_rejects_too_many_messages() -> None:
+    client: TestClient = TestClient(app)
+    response: Response = client.post(
+        "/api/v1/chat",
+        json={
+            "messages": [
+                {"role": "user", "parts": [{"type": "text", "text": "Hi"}]},
+            ]
+            * 51,
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_post_chat_rejects_message_content_too_long() -> None:
+    client: TestClient = TestClient(app)
+    response: Response = client.post(
+        "/api/v1/chat",
+        json={"messages": [{"role": "user", "content": "x" * 32_001}]},
+    )
+
+    assert response.status_code == 422
+
+
+def test_chat_endpoint_rate_limits_after_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def mock_stream(**_: object) -> Iterator[str]:
+        yield "ok"
+
+    monkeypatch.setattr("app.main.stream_azure_openai_response", mock_stream)
+    monkeypatch.setattr(settings, "chat_rate_limit", "1/minute")
+    limiter._storage.reset()
+
+    client: TestClient = TestClient(app)
+    payload: dict[str, object] = {
+        "messages": [{"role": "user", "parts": [{"type": "text", "text": "Hi"}]}],
+    }
+
+    assert client.post("/api/v1/chat", json=payload).status_code == 200
+
+    response: Response = client.post("/api/v1/chat", json=payload)
+    assert response.status_code == 429
+    assert response.json() == {"detail": "Rate limit exceeded. Please try again later."}
+
+
 def test_health() -> None:
     client: TestClient = TestClient(app)
     response: Response = client.get("/health")
@@ -119,7 +166,8 @@ def test_ui_message_text_returns_joined_parts() -> None:
 
 def test_ui_message_rejects_empty_content_and_parts() -> None:
     with pytest.raises(
-        ValidationError, match="At least one of 'content' or 'parts' must be provided"
+        ValidationError,
+        match="At least one of 'content' or 'parts' must be provided",
     ):
         UIMessage(role=OpenAIMessageRole.USER)
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 import httpx
 import openai
 import pytest
+from fastapi import status
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
@@ -32,7 +33,12 @@ def test_post_chat_stream_success(monkeypatch: pytest.MonkeyPatch) -> None:
             "messages": [
                 {
                     "role": "user",
-                    "parts": [{"type": "text", "text": "Hi"}],
+                    "parts": [
+                        {
+                            "type": "text",
+                            "text": "Hi",
+                        },
+                    ],
                 },
             ],
             "model": "gpt-4o-mini",
@@ -40,7 +46,7 @@ def test_post_chat_stream_success(monkeypatch: pytest.MonkeyPatch) -> None:
         },
     )
 
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "Hello world"
     assert response.headers["content-type"].startswith("text/plain")
     assert calls == [
@@ -57,11 +63,21 @@ def test_post_chat_rejects_empty_messages() -> None:
     response: Response = client.post(
         "/api/v1/chat",
         json={
-            "messages": [{"role": "user", "parts": [{"type": "text", "text": "  "}]}],
+            "messages": [
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "text": "  ",
+                        },
+                    ],
+                },
+            ],
         },
     )
 
-    assert response.status_code == 400
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json() == {"detail": "At least one text message is required."}
 
 
@@ -81,13 +97,23 @@ def test_post_chat_rejects_invalid_model_or_temperature(
     response: Response = client.post(
         "/api/v1/chat",
         json={
-            "messages": [{"role": "user", "parts": [{"type": "text", "text": "Hi"}]}],
+            "messages": [
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "text": "Hi",
+                        },
+                    ],
+                },
+            ],
             "model": model,
             "temperature": temperature,
         },
     )
 
-    assert response.status_code == 422
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_post_chat_rejects_too_many_messages() -> None:
@@ -96,23 +122,38 @@ def test_post_chat_rejects_too_many_messages() -> None:
         "/api/v1/chat",
         json={
             "messages": [
-                {"role": "user", "parts": [{"type": "text", "text": "Hi"}]},
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "text": "Hi",
+                        },
+                    ],
+                },
             ]
             * 51,
         },
     )
 
-    assert response.status_code == 422
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_post_chat_rejects_message_content_too_long() -> None:
     client: TestClient = TestClient(app)
     response: Response = client.post(
         "/api/v1/chat",
-        json={"messages": [{"role": "user", "content": "x" * 32_001}]},
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "x" * 32_001,
+                },
+            ],
+        },
     )
 
-    assert response.status_code == 422
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_chat_endpoint_rate_limits_after_threshold(
@@ -127,13 +168,23 @@ def test_chat_endpoint_rate_limits_after_threshold(
 
     client: TestClient = TestClient(app)
     payload: dict[str, object] = {
-        "messages": [{"role": "user", "parts": [{"type": "text", "text": "Hi"}]}],
+        "messages": [
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "type": "text",
+                        "text": "Hi",
+                    },
+                ],
+            },
+        ],
     }
 
-    assert client.post("/api/v1/chat", json=payload).status_code == 200
+    assert client.post("/api/v1/chat", json=payload).status_code == status.HTTP_200_OK
 
     response: Response = client.post("/api/v1/chat", json=payload)
-    assert response.status_code == 429
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
     assert response.json() == {"detail": "Rate limit exceeded. Please try again later."}
 
 
@@ -141,7 +192,7 @@ def test_health() -> None:
     client: TestClient = TestClient(app)
     response: Response = client.get("/health")
 
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"status": "ok"}
 
 
@@ -187,7 +238,15 @@ def test_stream_chat_reraises_non_openai_exception(
             "/api/v1/chat",
             json={
                 "messages": [
-                    {"role": "user", "parts": [{"type": "text", "text": "Hi"}]},
+                    {
+                        "role": "user",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "text": "Hi",
+                            },
+                        ],
+                    },
                 ],
             },
         )
@@ -206,12 +265,12 @@ def _make_openai_response(status_code: int) -> httpx.Response:
     [
         openai.RateLimitError(
             "rate limit",
-            response=_make_openai_response(429),
+            response=_make_openai_response(status.HTTP_429_TOO_MANY_REQUESTS),
             body=None,
         ),
         openai.AuthenticationError(
             "auth failed",
-            response=_make_openai_response(401),
+            response=_make_openai_response(status.HTTP_401_UNAUTHORIZED),
             body=None,
         ),
         openai.APIConnectionError(
@@ -220,7 +279,7 @@ def _make_openai_response(status_code: int) -> httpx.Response:
         ),
         openai.InternalServerError(
             "server error",
-            response=_make_openai_response(500),
+            response=_make_openai_response(status.HTTP_500_INTERNAL_SERVER_ERROR),
             body=None,
         ),
     ],
@@ -242,7 +301,15 @@ def test_stream_chat_reraises_openai_api_errors(
             "/api/v1/chat",
             json={
                 "messages": [
-                    {"role": "user", "parts": [{"type": "text", "text": "Hi"}]},
+                    {
+                        "role": "user",
+                        "parts": [
+                            {
+                                "type": "text",
+                                "text": "Hi",
+                            },
+                        ],
+                    },
                 ],
             },
         )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -458,6 +458,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -921,6 +933,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
     { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
     { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -1767,6 +1793,7 @@ dependencies = [
     { name = "loguru" },
     { name = "openai" },
     { name = "pydantic-settings" },
+    { name = "slowapi" },
 ]
 
 [package.dev-dependencies]
@@ -1788,6 +1815,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "openai", specifier = ">=2.34.0" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
+    { name = "slowapi", specifier = ">=0.1.9" },
 ]
 
 [package.metadata.requires-dev]
@@ -1822,6 +1850,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b0/d4/bfa032f961103eba93de583b161f0e6a5b63cebb8f2c7d0c6e6efe1e3d2e/simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4", size = 17300, upload-time = "2024-10-10T22:39:31.412Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c", size = 13842, upload-time = "2024-10-10T22:39:29.645Z" },
+]
+
+[[package]]
+name = "slowapi"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
 ]
 
 [[package]]
@@ -2100,6 +2140,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]

--- a/frontend/e2e-tests/chat-page.spec.ts
+++ b/frontend/e2e-tests/chat-page.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { StatusCodes } from "http-status-codes";
 import { getModelDisplay, getTemperatureDisplay } from "@/client/helpers";
 import { AssistantModel, AssistantTemperature } from "@/client/types/assistant";
 
@@ -31,7 +32,7 @@ test.describe("Chat Page Model and Temperature Combinations", () => {
       await route.fulfill({
         body: expectedResponse,
         contentType: "text/plain; charset=utf-8",
-        status: 200,
+        status: StatusCodes.OK,
       });
     });
 

--- a/frontend/e2e-tests/visual.spec.ts
+++ b/frontend/e2e-tests/visual.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { StatusCodes } from "http-status-codes";
 
 const CHAT_API_PATH = "**/api/v1/chat";
 
@@ -29,7 +30,7 @@ test.describe("Visual regression", () => {
       await route.fulfill({
         body: response,
         contentType: "text/plain; charset=utf-8",
-        status: 200,
+        status: StatusCodes.OK,
       });
     });
     await page.goto("/chat");

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,6 +58,7 @@
     "eslint-plugin-react-dom": "^5.7.2",
     "fallow": "^2.64.0",
     "globals": "^17.6.0",
+    "http-status-codes": "^2.3.0",
     "jsdom": "^29.1.1",
     "type-coverage": "^2.29.7",
     "typescript": "^6.0.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       globals:
         specifier: ^17.6.0
         version: 17.6.0
+      http-status-codes:
+        specifier: ^2.3.0
+        version: 2.3.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -1325,6 +1328,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  http-status-codes@2.3.0:
+    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -3402,6 +3408,8 @@ snapshots:
   html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
+
+  http-status-codes@2.3.0: {}
 
   ignore@5.3.2: {}
 


### PR DESCRIPTION
## Summary

- **Rate limiting**: integrates `slowapi` (IP-based, default 10 req/min) on the `/api/v1/chat` endpoint — configurable via the `CHAT_RATE_LIMIT` env var. Returns `{"detail": "Rate limit exceeded. Please try again later."}` with HTTP 429 when exceeded.
- **Request-size limits**: adds Pydantic `max_length` constraints — 50 messages per request, 32 000 characters per message (content field and part text). FastAPI returns HTTP 422 with validation details when exceeded.
- Adds `slowapi>=0.1.9` to dependencies; pins the Python 3.14 `asyncio.iscoroutinefunction` deprecation warning as an ignored warning in pytest (slowapi 0.1.9 still calls the old API internally).

## Test plan

- [ ] `make qa` passes — all 40 backend tests green, 100% line + branch coverage
- [ ] `test_chat_endpoint_rate_limits_after_threshold` — patches limit to 1/min, verifies first request is 200 and second is 429
- [ ] `test_post_chat_rejects_too_many_messages` — 51-message payload → 422
- [ ] `test_post_chat_rejects_message_content_too_long` — 32 001-char content → 422
- [ ] `test_settings_default_chat_rate_limit` — verifies `CHAT_RATE_LIMIT` defaults to `"10/minute"`