### PR TITLE
chore: raise Lighthouse thresholds to perfect scores for controllable categories

### DIFF
--- a/frontend/.lighthouserc.json
+++ b/frontend/.lighthouserc.json
@@ -14,9 +14,9 @@
     "assert": {
       "assertions": {
         "categories:performance": ["warn", { "minScore": 0.9 }],
-        "categories:accessibility": ["error", { "minScore": 0.95 }],
-        "categories:best-practices": ["error", { "minScore": 0.95 }],
-        "categories:seo": ["error", { "minScore": 0.9 }]
+        "categories:accessibility": ["error", { "minScore": 1 }],
+        "categories:best-practices": ["error", { "minScore": 1 }],
+        "categories:seo": ["error", { "minScore": 1 }]
       }
     },
     "upload": {


### PR DESCRIPTION
## Summary

- Raise Lighthouse CI assertion thresholds to `1.0` (perfect) for **accessibility**, **best-practices**, and **SEO** — all three currently score 100 and are fully in our control
- Keep **performance** at `0.9` with `warn` level since it fluctuates based on CI runner hardware and isn't fully deterministic
- `@lhci/cli@0.15.1` is already the latest version — no upgrade needed

### Threshold changes

| Category | Before | After |
|---|---|---|
| performance | `warn` @ 0.9 | `warn` @ 0.9 (unchanged) |
| accessibility | `error` @ 0.95 | `error` @ 1.0 |
| best-practices | `error` @ 0.95 | `error` @ 1.0 |
| seo | `error` @ 0.9 | `error` @ 1.0 |

## Test plan

- [x] Verified locally: `lhci collect` + `lhci assert` pass with all new thresholds
- [x] All individual audits in SEO, accessibility, and best-practices pass with score 1.0
- [ ] CI pipeline passes