### PR TITLE
chore(ci): suppress Codecov auto-discovery warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,8 @@ jobs:
           files: backend/coverage.xml
           flags: backend
           fail_ci_if_error: false
+          disable_search: true
+          plugins: noop
 
       - name: Upload backend coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -86,6 +88,8 @@ jobs:
           files: frontend/coverage/lcov.info
           flags: frontend
           fail_ci_if_error: false
+          disable_search: true
+          plugins: noop
 
       - name: Upload frontend coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1


### PR DESCRIPTION
## Summary

- Adds `disable_search: true` and `plugins: noop` to both Codecov upload steps in `tests.yml`
- Since coverage files are already specified explicitly via the `files:` option, the auto-discovery is unnecessary and produces noisy warnings about missing `gcov`, `coverage.py`, and `xcrun` in CI logs

## Context

Audited all workflow logs for commit ad8610c. Most warnings come from external tools (pnpm runner layout, Docker base image, Trivy, Lighthouse subdeps) and are not in our control. The only actionable warnings were from Codecov's auto-discovery scanning for coverage formats we don't use.

## Test plan

- [ ] Verify the `backend` and `frontend` jobs in the "Unit Tests" workflow pass without Codecov warnings