### PR TITLE
fix: address website-spec security, performance, and PWA gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ perfect score (100%) for accessibility, best-practices, and SEO, with
 performance at ≥ 90% (warn-only). Automated checks do not cover every AA
 criterion, so manual verification is also required for new UI.
 
+The app has also been reviewed against [The Website
+Specification](https://specification.website/checklist/), a broad checklist of
+web good practices. The relevant items — document foundations, security
+response headers, nginx caching and compression, and PWA metadata — are
+implemented in `frontend/index.html`, `frontend/frontend.nginx.conf`, and
+`frontend/app/favicon/site.webmanifest`. The SEO, internationalisation, and
+agent-readiness categories are intentionally out of scope for an internal
+chatbot SPA. Deferred items to revisit if deployment changes: HSTS (depends on
+where TLS terminates), and shipping fonts as WOFF2.
+
 ## Setup
 
 - Clone the repository

--- a/frontend/app/favicon/site.webmanifest
+++ b/frontend/app/favicon/site.webmanifest
@@ -1,7 +1,25 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "Chatbot Template",
+  "short_name": "Chatbot",
+  "description": "A minimal full-stack chatbot template built with React and FastAPI.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "theme_color": "#121212",
+  "background_color": "#121212",
   "icons": [
+    {
+      "src": "/web-app-manifest-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/web-app-manifest-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
     {
       "src": "/web-app-manifest-192x192.png",
       "sizes": "192x192",
@@ -14,8 +32,5 @@
       "type": "image/png",
       "purpose": "maskable"
     }
-  ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
-  "display": "standalone"
+  ]
 }

--- a/frontend/frontend.nginx.conf
+++ b/frontend/frontend.nginx.conf
@@ -9,12 +9,37 @@ http {
   include /etc/nginx/mime.types;
   default_type application/octet-stream;
 
+  # Fingerprinted build assets (assets/[name]-[hash].*) can be cached
+  # forever; everything else (index.html, favicons, manifest) must be
+  # revalidated so a new deploy is picked up immediately.
+  map $uri $cache_control {
+    default             "no-cache";
+    ~^/assets/          "public, max-age=31536000, immutable";
+  }
+
   access_log /dev/stdout;
   error_log /dev/stderr warn;
 
   sendfile on;
   tcp_nopush on;
   keepalive_timeout 65;
+
+  # Compress text responses. Brotli needs a module not shipped with
+  # nginx-light, so gzip covers every client here. Already-compressed
+  # media (images, fonts, wasm) is deliberately excluded.
+  gzip on;
+  gzip_vary on;
+  gzip_comp_level 6;
+  gzip_min_length 256;
+  gzip_proxied any;
+  gzip_types
+    application/javascript
+    application/json
+    application/manifest+json
+    application/xml
+    image/svg+xml
+    text/css
+    text/plain;
 
   client_body_temp_path /tmp/nginx/client-body;
   proxy_temp_path /tmp/nginx/proxy;
@@ -28,6 +53,16 @@ http {
 
     root /usr/share/nginx/html;
     index index.html;
+
+    # Security and caching headers for every response. Kept at server
+    # level so the location blocks below inherit them — an add_header
+    # inside a location would replace (not extend) this whole set.
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
+    add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; form-action 'self'; upgrade-insecure-requests" always;
+    add_header Cache-Control $cache_control always;
 
     location /api/ {
       proxy_pass http://backend:8000;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,12 +8,23 @@
     />
     <meta
       name="description"
-      content="Built as a hobby full-stack project"
+      content="A minimal full-stack chatbot template built with React and FastAPI."
     />
-    <meta name="theme-color" content="#121212" />
+    <meta name="color-scheme" content="dark light" />
+    <meta
+      name="theme-color"
+      content="#121212"
+      media="(prefers-color-scheme: dark)"
+    />
+    <meta
+      name="theme-color"
+      content="#ffffff"
+      media="(prefers-color-scheme: light)"
+    />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
     <title>Chatbot Template</title>
   </head>
   <body>


### PR DESCRIPTION
## What & why

Audited the app against [specification.website/checklist.md](https://specification.website/checklist.md) and fixed the items that genuinely apply to this project in one PR.

**Out of scope (not relevant to an internal chatbot SPA):** SEO, i18n, and agent-readiness categories. **Already compliant:** accessibility is strong — skip link, semantic landmarks, visually-hidden `<h1>`, labelled inputs, `aria-hidden` spinner, 56px touch targets, `dvh` units, `prefers-color-scheme` handling.

The real violations were concentrated in security headers, nginx performance defaults, and leftover PWA/foundations placeholders.

## Changes

### Security — `frontend.nginx.conf` (no headers were set before)
| Header | Spec severity |
|---|---|
| `X-Content-Type-Options: nosniff` | Required |
| `X-Frame-Options: DENY` + CSP `frame-ancestors 'none'` | Required |
| `Content-Security-Policy` (locked down) | Recommended |
| `Referrer-Policy: strict-origin-when-cross-origin` | Recommended |
| `Permissions-Policy` (camera/mic/geo/payment/usb off) | Recommended |

CSP allows `style-src 'unsafe-inline'` (required by MUI/emotion runtime styles) and otherwise restricts to `'self'`. Headers live at the server level so both locations inherit them.

### Performance — `frontend.nginx.conf`
- **gzip** for text responses (Required). Brotli needs a module absent from `nginx-light`; media stays uncompressed.
- **Cache-Control** via a `map` (Required): `immutable, max-age=1y` for fingerprinted `/assets/`, `no-cache` for `index.html`/favicons/manifest so deploys are picked up immediately.

### Foundations — `index.html`
- Add `<meta name="color-scheme" content="dark light">` — prevents the white flash on the dark-default UI (Recommended).
- Split `theme-color` into light/dark `media` variants.
- **Link the web app manifest** — it was shipped to `/site.webmanifest` but never referenced.
- Replace the placeholder meta description.

### PWA — `site.webmanifest`
- Replace template placeholders (`MyWebSite`, white theme on a dark-default app), add `start_url`/`scope`/`description`, and provide both `any` and `maskable` icon purposes.

## Verification
- `pnpm build` passes; manifest lands in `dist/` root and is linked from `index.html`.
- `pnpm lint` (biome + eslint) clean.
- `nginx -t` parses the full config successfully (only the expected `backend` upstream-DNS notice, which resolves inside the compose network).

## Notes / deliberately left out
- **HSTS / HTTPS-redirect** depend on where TLS terminates (ingress/CDN), not this container — not added here.
- **WOFF2 fonts**: the bundled Geist faces are `.woff`; converting to `.woff2` is a nice-to-have that needs conversion tooling.
- CSP `img-src` is `'self' data:`, so external images in assistant markdown would be blocked — a secure default a template author can relax if needed.