### PR TITLE
perf(frontend): code-split markdown and adopt the React Compiler

### DIFF
--- a/frontend/.fallowrc.json
+++ b/frontend/.fallowrc.json
@@ -6,7 +6,8 @@
     "@ai-sdk/__mocks__",
     "@emotion/react",
     "@emotion/styled",
-    "@mui/__mocks__"
+    "@mui/__mocks__",
+    "babel-plugin-react-compiler"
   ],
   "rules": {
     "unused-files": "error",

--- a/frontend/client/useChatSetup.ts
+++ b/frontend/client/useChatSetup.ts
@@ -1,6 +1,5 @@
 import { useChat } from "@ai-sdk/react";
 import { TextStreamChatTransport } from "ai";
-import { useMemo } from "react";
 import { CHAT_API_URL, INITIAL_MESSAGES } from "@/client/chatConstants";
 import type {
   AssistantModel,
@@ -11,10 +10,9 @@ function useChatSetup(
   model: AssistantModel,
   temperature: AssistantTemperature,
 ) {
-  const transport = useMemo(
-    () => new TextStreamChatTransport({ api: CHAT_API_URL }),
-    [],
-  );
+  // The React Compiler memoizes this dependency-free constructor call once for
+  // the hook's lifetime, matching the previous useMemo(…, []) behavior.
+  const transport = new TextStreamChatTransport({ api: CHAT_API_URL });
   const { messages, sendMessage, regenerate, error, status } = useChat({
     messages: INITIAL_MESSAGES,
     transport,

--- a/frontend/client/useDarkMode.ts
+++ b/frontend/client/useDarkMode.ts
@@ -1,5 +1,5 @@
 import { createTheme } from "@mui/material/styles";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 const DARK_THEME_COLOR = "#121212";
 const LIGHT_THEME_COLOR = "#ffffff";
@@ -22,10 +22,7 @@ function useDarkMode() {
     syncBrowserTheme(darkMode);
   }, [darkMode]);
 
-  const theme = useMemo(
-    () => createTheme({ palette: { mode: darkMode ? "dark" : "light" } }),
-    [darkMode],
-  );
+  const theme = createTheme({ palette: { mode: darkMode ? "dark" : "light" } });
 
   const toggleDarkMode = () => setDarkMode((prev) => !prev);
 

--- a/frontend/components/messages/AssistantMessage.test.tsx
+++ b/frontend/components/messages/AssistantMessage.test.tsx
@@ -58,7 +58,7 @@ describe("AssistantMessage", () => {
     ["plain text", "This is a simple text message"],
     ["empty content", ""],
     ["inline code", "Use the `console.log()` function"],
-  ])("renders %s without error", (_label, content) => {
+  ])("renders %s without error", async (_label, content) => {
     render(
       <AssistantMessage
         content={content}
@@ -66,10 +66,10 @@ describe("AssistantMessage", () => {
       />,
       { wrapper: Wrapper },
     );
-    expect(screen.getByTestId("markdown-content")).toBeInTheDocument();
+    expect(await screen.findByTestId("markdown-content")).toBeInTheDocument();
   });
 
-  test("renders code block with block container", () => {
+  test("renders code block with block container", async () => {
     render(
       <AssistantMessage
         content={'```javascript\nconsole.log("hello");\n```'}
@@ -77,8 +77,8 @@ describe("AssistantMessage", () => {
       />,
       { wrapper: Wrapper },
     );
-    expect(screen.getByTestId("markdown-content")).toBeInTheDocument();
-    expect(screen.getByTestId("code-block")).toBeInTheDocument();
+    expect(await screen.findByTestId("markdown-content")).toBeInTheDocument();
+    expect(await screen.findByTestId("code-block")).toBeInTheDocument();
   });
 
   test("does not show copy button when isFirstMessage is true", () => {

--- a/frontend/components/messages/AssistantMessage.tsx
+++ b/frontend/components/messages/AssistantMessage.tsx
@@ -2,9 +2,15 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import SmartToyIcon from "@mui/icons-material/SmartToy";
 import { Box, IconButton, Paper, Tooltip, Typography } from "@mui/material";
 import type React from "react";
-import { useMemo, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
+import { lazy, Suspense, useMemo, useRef, useState } from "react";
 import { useIsDark } from "@/client/hooks";
+
+// Load the markdown renderer lazily so it stays off the initial critical
+// path. The first paint (including the LCP greeting) renders the message
+// text as-is via the Suspense fallback, then upgrades to rendered markdown
+// once the chunk arrives — visually identical for plain text, so no layout
+// shift.
+const ReactMarkdown = lazy(() => import("react-markdown"));
 
 const DARK_COLORS = {
   codeBlock: "#1e1e1e",
@@ -166,9 +172,11 @@ const AssistantMessage: React.FC<AssistantMessageProps> = ({
           variant="body1"
           component="div"
         >
-          <ReactMarkdown components={markdownComponents}>
-            {content}
-          </ReactMarkdown>
+          <Suspense fallback={content}>
+            <ReactMarkdown components={markdownComponents}>
+              {content}
+            </ReactMarkdown>
+          </Suspense>
         </Typography>
         {!isFirstMessage && (
           <CopyButton

--- a/frontend/components/messages/AssistantMessage.tsx
+++ b/frontend/components/messages/AssistantMessage.tsx
@@ -2,7 +2,7 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import SmartToyIcon from "@mui/icons-material/SmartToy";
 import { Box, IconButton, Paper, Tooltip, Typography } from "@mui/material";
 import type React from "react";
-import { lazy, Suspense, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useRef, useState } from "react";
 import { useIsDark } from "@/client/hooks";
 
 // Load the markdown renderer lazily so it stays off the initial critical
@@ -114,38 +114,37 @@ function CopyButton({ content, isDark }: CopyButtonProps) {
 
 type ThemeColors = typeof DARK_COLORS | typeof LIGHT_COLORS;
 
+// The React Compiler memoizes this object by its `colors` dependency, so no
+// manual useMemo is needed to keep the reference stable across renders.
 function useMarkdownComponents(colors: ThemeColors) {
-  return useMemo(
-    () => ({
-      pre: ({ children }: React.ComponentPropsWithoutRef<"pre">) => (
-        <Box
-          component="pre"
-          data-testid="code-block"
-          sx={[CODE_BLOCK_PRE_SX, { backgroundColor: colors.codeBlock }]}
+  return {
+    pre: ({ children }: React.ComponentPropsWithoutRef<"pre">) => (
+      <Box
+        component="pre"
+        data-testid="code-block"
+        sx={[CODE_BLOCK_PRE_SX, { backgroundColor: colors.codeBlock }]}
+      >
+        {children}
+      </Box>
+    ),
+    code: ({
+      className = "",
+      children,
+    }: React.ComponentPropsWithoutRef<"code">) => {
+      const language = className.match(/language-(\w+)/)?.[1];
+      const text = String(children ?? "");
+      if (language || text.includes("\n")) {
+        return <BlockCode text={text} />;
+      }
+      return (
+        <code
+          style={{ backgroundColor: colors.inlineBg, color: colors.inlineFg }}
         >
           {children}
-        </Box>
-      ),
-      code: ({
-        className = "",
-        children,
-      }: React.ComponentPropsWithoutRef<"code">) => {
-        const language = className.match(/language-(\w+)/)?.[1];
-        const text = String(children ?? "");
-        if (language || text.includes("\n")) {
-          return <BlockCode text={text} />;
-        }
-        return (
-          <code
-            style={{ backgroundColor: colors.inlineBg, color: colors.inlineFg }}
-          >
-            {children}
-          </code>
-        );
-      },
-    }),
-    [colors],
-  );
+        </code>
+      );
+    },
+  };
 }
 
 interface AssistantMessageProps {

--- a/frontend/components/messages/AssistantMessage.tsx
+++ b/frontend/components/messages/AssistantMessage.tsx
@@ -52,6 +52,16 @@ const CODE_BLOCK_PRE_SX = {
   p: 2,
 } as const;
 
+// Paragraphs get spacing between them, but the outer edges collapse so a
+// single-paragraph message (e.g. the greeting) renders with no vertical
+// margin — matching the raw-text Suspense fallback exactly, so upgrading to
+// rendered markdown causes no layout shift.
+const MARKDOWN_P_SX = {
+  my: 2,
+  "&:first-of-type": { mt: 0 },
+  "&:last-of-type": { mb: 0 },
+} as const;
+
 const ASSISTANT_MESSAGE_CONTAINER_SX = {
   display: "flex",
   justifyContent: "flex-start",
@@ -118,6 +128,14 @@ type ThemeColors = typeof DARK_COLORS | typeof LIGHT_COLORS;
 // manual useMemo is needed to keep the reference stable across renders.
 function useMarkdownComponents(colors: ThemeColors) {
   return {
+    p: ({ children }: React.ComponentPropsWithoutRef<"p">) => (
+      <Box
+        component="p"
+        sx={MARKDOWN_P_SX}
+      >
+        {children}
+      </Box>
+    ),
     pre: ({ children }: React.ComponentPropsWithoutRef<"pre">) => (
       <Box
         component="pre"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,11 +43,14 @@
     ]
   },
   "devDependencies": {
+    "@babel/core": "^8.0.1",
     "@biomejs/biome": "2.5.2",
     "@playwright/test": "^1.61.1",
     "@projectwallace/css-code-quality": "^3.1.3",
+    "@rolldown/plugin-babel": "^0.2.3",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/babel__core": "^7.20.5",
     "@types/node": "^26.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
@@ -55,6 +58,7 @@
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.9",
     "axe-core": "^4.12.1",
+    "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^10.6.0",
     "eslint-plugin-no-unsanitized": "^4.1.5",
     "eslint-plugin-react-dom": "^5.10.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
     devDependencies:
+      '@babel/core':
+        specifier: ^8.0.1
+        version: 8.0.1
       '@biomejs/biome':
         specifier: 2.5.2
         version: 2.5.2
@@ -45,12 +48,18 @@ importers:
       '@projectwallace/css-code-quality':
         specifier: ^3.1.3
         version: 3.1.3
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.3
+        version: 0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/babel__core':
+        specifier: ^7.20.5
+        version: 7.20.5
       '@types/node':
         specifier: ^26.1.0
         version: 26.1.0
@@ -65,13 +74,16 @@ importers:
         version: 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(vite@8.1.3(@types/node@26.1.0))
+        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@26.1.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
       axe-core:
         specifier: ^4.12.1
         version: 4.12.1
+      babel-plugin-react-compiler:
+        specifier: 1.0.0
+        version: 1.0.0
       eslint:
         specifier: ^10.6.0
         version: 10.6.0
@@ -158,13 +170,37 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@8.0.0':
+    resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/compat-data@8.0.0':
+    resolution: {integrity: sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/core@8.0.1':
+    resolution: {integrity: sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/generator@7.29.7':
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@8.0.0':
+    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-compilation-targets@8.0.0':
+    resolution: {integrity: sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@8.0.0':
+    resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-module-imports@7.29.7':
     resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
@@ -174,13 +210,34 @@ packages:
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@8.0.2':
+    resolution: {integrity: sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-validator-option@8.0.0':
+    resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helpers@8.0.0':
+    resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@8.0.0':
+    resolution: {integrity: sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/runtime@7.29.7':
@@ -191,13 +248,25 @@ packages:
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@8.0.0':
+    resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@8.0.0':
+    resolution: {integrity: sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.0':
+    resolution: {integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -741,6 +810,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/plugin-babel@0.2.3':
+    resolution: {integrity: sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==}
+    engines: {node: '>=22.12.0 || ^24.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
+      rolldown: ^1.0.0-rc.5
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@babel/plugin-transform-runtime':
+        optional: true
+      '@babel/runtime':
+        optional: true
+      vite:
+        optional: true
+
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
@@ -776,6 +862,18 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -794,8 +892,14 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/gensync@1.0.5':
+    resolution: {integrity: sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/jsesc@2.5.1':
+    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -992,12 +1096,20 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
 
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  baseline-browser-mapping@2.10.41:
+    resolution: {integrity: sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -1010,9 +1122,17 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browserslist@4.28.4:
+    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  caniuse-lite@1.0.30001800:
+    resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1120,6 +1240,13 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  electron-to-chromium@1.5.387:
+    resolution: {integrity: sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==}
+
+  empathic@2.0.1:
+    resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
+    engines: {node: '>=14'}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
@@ -1133,6 +1260,10 @@ packages:
 
   es-module-lexer@2.3.0:
     resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1274,6 +1405,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1323,6 +1458,9 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -1422,6 +1560,11 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1655,6 +1798,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-releases@2.0.50:
+    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
+    engines: {node: '>=18'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -2010,6 +2157,12 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -2227,6 +2380,32 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@8.0.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.2
+      js-tokens: 10.0.0
+
+  '@babel/compat-data@8.0.0': {}
+
+  '@babel/core@8.0.1':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-compilation-targets': 8.0.0
+      '@babel/helpers': 8.0.0
+      '@babel/parser': 8.0.0
+      '@babel/template': 8.0.0
+      '@babel/traverse': 8.0.0
+      '@babel/types': 8.0.0
+      '@types/gensync': 1.0.5
+      convert-source-map: 2.0.0
+      empathic: 2.0.1
+      gensync: 1.0.0-beta.2
+      import-meta-resolve: 4.2.0
+      json5: 2.2.3
+      obug: 2.1.3
+      semver: 7.8.5
+
   '@babel/generator@7.29.7':
     dependencies:
       '@babel/parser': 7.29.7
@@ -2235,7 +2414,26 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@8.0.0':
+    dependencies:
+      '@babel/parser': 8.0.0
+      '@babel/types': 8.0.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@8.0.0':
+    dependencies:
+      '@babel/compat-data': 8.0.0
+      '@babel/helper-validator-option': 8.0.0
+      browserslist: 4.28.4
+      lru-cache: 11.5.1
+      semver: 7.8.5
+
   '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-globals@8.0.0': {}
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
@@ -2246,11 +2444,26 @@ snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
 
+  '@babel/helper-string-parser@8.0.0': {}
+
   '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-identifier@8.0.2': {}
+
+  '@babel/helper-validator-option@8.0.0': {}
+
+  '@babel/helpers@8.0.0':
+    dependencies:
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.0
 
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/parser@8.0.0':
+    dependencies:
+      '@babel/types': 8.0.0
 
   '@babel/runtime@7.29.7': {}
 
@@ -2259,6 +2472,12 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
+
+  '@babel/template@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/parser': 8.0.0
+      '@babel/types': 8.0.0
 
   '@babel/traverse@7.29.7':
     dependencies:
@@ -2272,10 +2491,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-globals': 8.0.0
+      '@babel/parser': 8.0.0
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.0
+      obug: 2.1.3
+
   '@babel/types@7.29.7':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@8.0.0':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.2
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -2760,6 +2994,15 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.1.4':
     optional: true
 
+  '@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0))':
+    dependencies:
+      '@babel/core': 8.0.1
+      picomatch: 4.0.5
+      rolldown: 1.1.4
+    optionalDependencies:
+      '@babel/runtime': 7.29.7
+      vite: 8.1.3(@types/node@26.1.0)
+
   '@rolldown/pluginutils@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -2801,6 +3044,27 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -2820,9 +3084,13 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/gensync@1.0.5': {}
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/jsesc@2.5.1': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -2923,10 +3191,13 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-react@6.0.3(vite@8.1.3(@types/node@26.1.0))':
+  '@vitejs/plugin-react@6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@26.1.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.3(@types/node@26.1.0)
+    optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0))
+      babel-plugin-react-compiler: 1.0.0
 
   '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
     dependencies:
@@ -3035,9 +3306,15 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.12
 
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.29.7
+
   bail@2.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  baseline-browser-mapping@2.10.41: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -3051,7 +3328,17 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browserslist@4.28.4:
+    dependencies:
+      baseline-browser-mapping: 2.10.41
+      caniuse-lite: 1.0.30001800
+      electron-to-chromium: 1.5.387
+      node-releases: 2.0.50
+      update-browserslist-db: 1.2.3(browserslist@4.28.4)
+
   callsites@3.1.0: {}
+
+  caniuse-lite@1.0.30001800: {}
 
   ccount@2.0.1: {}
 
@@ -3145,6 +3432,10 @@ snapshots:
       '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
+  electron-to-chromium@1.5.387: {}
+
+  empathic@2.0.1: {}
+
   entities@8.0.0: {}
 
   error-ex@1.3.4:
@@ -3154,6 +3445,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@2.3.0: {}
+
+  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3316,6 +3609,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gensync@1.0.0-beta.2: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -3378,6 +3673,8 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
 
@@ -3470,6 +3767,8 @@ snapshots:
   json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@2.2.3: {}
 
   keyv@4.5.4:
     dependencies:
@@ -3803,6 +4102,8 @@ snapshots:
   nanoid@3.3.15: {}
 
   natural-compare@1.4.0: {}
+
+  node-releases@2.0.50: {}
 
   normalize-path@3.0.0: {}
 
@@ -4174,6 +4475,12 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  update-browserslist-db@1.2.3(browserslist@4.28.4):
+    dependencies:
+      browserslist: 4.28.4
+      escalade: 3.2.0
+      picocolors: 1.1.1
 
   uri-js@4.4.1:
     dependencies:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,13 +3,16 @@ import { fileURLToPath, URL } from "node:url";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
+// react-markdown is intentionally absent: it is dynamically imported by
+// AssistantMessage, so leaving it out of the manual chunks lets the bundler
+// emit it as an async chunk that stays off the initial critical path (no
+// eager modulepreload in index.html).
 const VENDOR_CHUNKS: [string, string][] = [
   ["react", "/react/"],
   ["react", "/react-dom/"],
   ["mui", "/@emotion/"],
   ["mui", "/@mui/icons-material/"],
   ["mui", "/@mui/material/"],
-  ["markdown", "/react-markdown/"],
 ];
 const CHAT_API_PROXY_TARGET =
   process.env.CHAT_API_PROXY_TARGET ?? "http://localhost:8000";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { fileURLToPath, URL } from "node:url";
 
 import babel from "@rolldown/plugin-babel";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
+import type { PluginOption } from "vite";
 import { defineConfig } from "vitest/config";
 
 // react-markdown is intentionally absent: it is dynamically imported by
@@ -32,7 +33,7 @@ const CHAT_API_PROXY = {
 // against the un-compiled source keeps coverage measuring the code we wrote
 // rather than the compiler's injected memo-cache guards.
 const isTest = process.env.VITEST === "true";
-const reactCompiler = isTest
+const reactCompiler: PluginOption[] = isTest
   ? []
   : [babel({ presets: [reactCompilerPreset()] })];
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath, URL } from "node:url";
 
-import react from "@vitejs/plugin-react";
+import babel from "@rolldown/plugin-babel";
+import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
 // react-markdown is intentionally absent: it is dynamically imported by
@@ -23,8 +24,20 @@ const CHAT_API_PROXY = {
   },
 };
 
+// The React Compiler auto-memoizes components and hooks, so manual useMemo/
+// useCallback/React.memo is unnecessary. It runs as a build-time Babel pass
+// (Vite 8 drives React Refresh through Oxc, so the compiler is wired in
+// separately via @rolldown/plugin-babel). We skip it under Vitest: memoization
+// is a performance optimization with no bearing on behavior, and running tests
+// against the un-compiled source keeps coverage measuring the code we wrote
+// rather than the compiler's injected memo-cache guards.
+const isTest = process.env.VITEST === "true";
+const reactCompiler = isTest
+  ? []
+  : [babel({ presets: [reactCompilerPreset()] })];
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), ...reactCompiler],
   publicDir: "app/favicon",
   server: {
     proxy: CHAT_API_PROXY,


### PR DESCRIPTION
## Summary

Two idiomatic frontend modernizations, plus a follow-up fix from review.

**1. Code-split the markdown renderer.** The ~116 KB (raw) `react-markdown`
chunk is no longer part of the initial download — the idiomatic React lever
for this template's Lighthouse performance (a client-only SPA whose first
paint is otherwise gated on the react + mui bundles).

- `AssistantMessage` now loads `react-markdown` via `React.lazy` + `Suspense`.
  The fallback renders the raw message text, so the greeting (and any
  assistant text) paints immediately and upgrades to rendered markdown once
  the async chunk arrives.
- `react-markdown` is removed from the manual vendor chunks. Left in, it was
  eagerly `modulepreload`ed in `index.html`, which defeated the split; out of
  the list, the bundler emits it as a true async chunk.
- The markdown `p` renderer collapses paragraph margins at the outer edges
  (`&:first-of-type { mt: 0 }`, `&:last-of-type { mb: 0 }`). A `<p>` otherwise
  carries the UA default `1em` margin that the raw-text fallback lacks, so a
  single-paragraph message — like the greeting — now matches the fallback
  exactly and the upgrade causes **no layout shift** (raised in review).

**2. Adopt the React Compiler (drive-by cleanup).** The compiler is enabled as
a build-time Babel pass via the official `reactCompilerPreset` +
`@rolldown/plugin-babel` (Vite 8 drives React Refresh through Oxc, so the
compiler is wired in separately). With auto-memoization in place, all three
manual `useMemo` sites are now redundant and removed:

- `useDarkMode` — the derived MUI `theme`
- `AssistantMessage` — the markdown component map
- `useChatSetup` — the chat `transport`

The compiler is skipped under Vitest so coverage measures the authored source
rather than the compiler's injected memo-cache guards. Behavior is identical
with or without memoization (it's a performance optimization, not semantics),
which the unchanged, passing test suite confirms — and is exactly why the
manual memos are safe to drop. Two supporting config touches keep QA green:
`babel-plugin-react-compiler` is allow-listed in `.fallowrc.json` (Babel loads
it by string name, so static analysis can't see the reference), and the
compiler plugin list is typed as `PluginOption[]` to hold strict type coverage
at 100%.

## Why not more?

I deliberately kept this idiomatic. A blank-until-JS SPA has a hard mobile
FCP/LCP floor set by shipping ~190 KB gzip of react + mui before anything
paints. The only genuine way past ~93 on mobile is server/static rendering
(real HTML before JS) — an architectural change, not a config tweak. Vite is
already optimal here: the default build target is modern (Baseline Widely
Available), the bundle is tree-shaken/minified, and `manualChunks` is not
deprecated in this version. The React Compiler optimizes re-render cost, not
initial load, so it leaves the score unchanged while removing hand-written
memoization boilerplate — a clearer best-practice signal for a template.

## Lighthouse (local, repo's mobile-throttled config)

| Form factor | Performance | A11y | Best-practices | SEO |
|-------------|-------------|------|----------------|-----|
| Desktop     | 100         | 100  | 100            | 100 |
| Mobile      | ~93 (median)| 100  | 100            | 100 |

Median mobile run: FCP 2.3 s, LCP 2.8 s, TBT 50 ms. `make lighthouse`
assertions pass.

## Testing

- `make qa` — pass (format, lint, type-check, tests, fallow, build, type
  coverage 100%, security scans)
- `pnpm run test` — 80 pass, coverage above thresholds (97.8% stmts, 88.9% branches)
- `make lighthouse` — assertions pass
