### PR TITLE
feat: full-stack type safety with Zod validation and frozen settings

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
         env_file=".env",
         extra="ignore",
+        frozen=True,
     )
 
     @field_validator("chat_rate_limit", mode="after")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,15 +10,17 @@ if TYPE_CHECKING:
 
 
 class Settings(BaseSettings):
-    azure_openai_endpoint: str = Field(default="", alias="AZURE_OPENAI_ENDPOINT")
-    azure_openai_api_key: str = Field(default="", alias="AZURE_OPENAI_API_KEY")
-    azure_openai_api_version: str = Field(default="", alias="AZURE_OPENAI_API_VERSION")
+    # pydantic-settings reads each field from its upper-cased name as the env var
+    # (AZURE_OPENAI_ENDPOINT, CHAT_RATE_LIMIT, TESTING, …) case-insensitively, so
+    # no explicit aliases are needed.
+    azure_openai_endpoint: str = ""
+    azure_openai_api_key: str = ""
+    azure_openai_api_version: str = ""
     cors_allowed_origins: list[str] = Field(
         default_factory=lambda: ["http://localhost:3000"],
-        alias="CORS_ALLOWED_ORIGINS",
     )
-    chat_rate_limit: str = Field(default="10/minute", alias="CHAT_RATE_LIMIT")
-    testing: bool = Field(default=False, alias="TESTING")
+    chat_rate_limit: str = "10/minute"
+    testing: bool = False
 
     model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
         env_file=".env",

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -11,10 +11,10 @@ if TYPE_CHECKING:
 
 def test_settings_valid_azure_credentials() -> None:
     s: Settings = Settings(
-        AZURE_OPENAI_ENDPOINT="https://example.openai.azure.com/",
-        AZURE_OPENAI_API_KEY="key",
-        AZURE_OPENAI_API_VERSION="2024-09-01-preview",
-        TESTING=False,
+        azure_openai_endpoint="https://example.openai.azure.com/",
+        azure_openai_api_key="key",
+        azure_openai_api_version="2024-09-01-preview",
+        testing=False,
     )
     assert s.azure_openai_endpoint == "https://example.openai.azure.com/"
     assert s.azure_openai_api_key == "key"
@@ -56,10 +56,10 @@ def test_settings_raises_on_missing_azure_credentials(
     )
     with pytest.raises(ValueError, match=pattern):
         Settings(
-            AZURE_OPENAI_ENDPOINT=endpoint,
-            AZURE_OPENAI_API_KEY=api_key,
-            AZURE_OPENAI_API_VERSION=api_version,
-            TESTING=False,
+            azure_openai_endpoint=endpoint,
+            azure_openai_api_key=api_key,
+            azure_openai_api_version=api_version,
+            testing=False,
         )
 
 
@@ -69,10 +69,10 @@ def test_settings_whitespace_values_treated_as_missing() -> None:
         match="Missing required Azure OpenAI settings: AZURE_OPENAI_API_KEY",
     ):
         Settings(
-            AZURE_OPENAI_ENDPOINT="https://example.openai.azure.com/",
-            AZURE_OPENAI_API_KEY="   ",
-            AZURE_OPENAI_API_VERSION="2024-09-01-preview",
-            TESTING=False,
+            azure_openai_endpoint="https://example.openai.azure.com/",
+            azure_openai_api_key="   ",
+            azure_openai_api_version="2024-09-01-preview",
+            testing=False,
         )
 
 
@@ -81,7 +81,7 @@ def test_settings_testing_mode_allows_empty_azure_credentials(
     tmp_path: Path,
 ) -> None:
     monkeypatch.chdir(tmp_path)
-    s: Settings = Settings(TESTING=True)
+    s: Settings = Settings(testing=True)
     assert s.azure_openai_endpoint == ""
     assert s.azure_openai_api_key == ""
     assert s.azure_openai_api_version == ""
@@ -93,13 +93,13 @@ def test_settings_default_chat_rate_limit(
     tmp_path: Path,
 ) -> None:
     monkeypatch.chdir(tmp_path)
-    s: Settings = Settings(TESTING=True)
+    s: Settings = Settings(testing=True)
     assert s.chat_rate_limit == "10/minute"
 
 
 def test_settings_raises_on_invalid_chat_rate_limit() -> None:
     with pytest.raises(ValueError, match="Invalid rate limit format: 10/minx"):
-        Settings(TESTING=True, CHAT_RATE_LIMIT="10/minx")
+        Settings(testing=True, chat_rate_limit="10/minx")
 
 
 def test_get_settings_returns_cached_instance() -> None:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -7,8 +7,9 @@ from fastapi import status
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
+from app.config import Settings
 from app.entities import AssistantModel, AssistantTemperature, OpenAIMessageRole
-from app.main import TextPart, UIMessage, app, limiter, settings
+from app.main import TextPart, UIMessage, app, limiter
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterator
@@ -164,7 +165,10 @@ def test_chat_endpoint_rate_limits_after_threshold(
         yield "ok"
 
     monkeypatch.setattr("app.main.stream_azure_openai_response", mock_stream)
-    monkeypatch.setattr(settings, "chat_rate_limit", "1/minute")
+    # `settings` is frozen, so swap the whole module-global instance (which the
+    # rate-limit lambda reads at call time) instead of mutating it in place.
+    low_limit_settings: Settings = Settings(TESTING=True, CHAT_RATE_LIMIT="1/minute")
+    monkeypatch.setattr("app.main.settings", low_limit_settings)
 
     payload: dict[str, object] = {"messages": [hi_message]}
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -167,7 +167,7 @@ def test_chat_endpoint_rate_limits_after_threshold(
     monkeypatch.setattr("app.main.stream_azure_openai_response", mock_stream)
     # `settings` is frozen, so swap the whole module-global instance (which the
     # rate-limit lambda reads at call time) instead of mutating it in place.
-    low_limit_settings: Settings = Settings(TESTING=True, CHAT_RATE_LIMIT="1/minute")
+    low_limit_settings: Settings = Settings(testing=True, chat_rate_limit="1/minute")
     monkeypatch.setattr("app.main.settings", low_limit_settings)
 
     payload: dict[str, object] = {"messages": [hi_message]}

--- a/frontend/client/chatConstants.ts
+++ b/frontend/client/chatConstants.ts
@@ -1,7 +1,16 @@
 import type { UIMessage } from "@ai-sdk/react";
+import { z } from "zod";
 
 const INITIAL_MESSAGE_ID = "initial-message";
 const CHAT_API_URL = "/api/v1/chat";
+
+// Mirror the backend's per-message limit (`_MAX_MESSAGE_CHARS` in app/main.py)
+// so the client can give instant feedback before a server round-trip.
+const MAX_MESSAGE_CHARS = 32_000;
+
+// Same rule the server enforces: non-empty after trimming, within the size cap.
+// Client-side validation is for UX; the server still validates for security.
+const ChatMessageTextSchema = z.string().trim().min(1).max(MAX_MESSAGE_CHARS);
 const INITIAL_MESSAGES: UIMessage[] = [
   {
     id: INITIAL_MESSAGE_ID,
@@ -12,4 +21,10 @@ const INITIAL_MESSAGES: UIMessage[] = [
   },
 ];
 
-export { CHAT_API_URL, INITIAL_MESSAGE_ID, INITIAL_MESSAGES };
+export {
+  CHAT_API_URL,
+  ChatMessageTextSchema,
+  INITIAL_MESSAGE_ID,
+  INITIAL_MESSAGES,
+  MAX_MESSAGE_CHARS,
+};

--- a/frontend/client/types/assistant.test.ts
+++ b/frontend/client/types/assistant.test.ts
@@ -1,4 +1,9 @@
-import { AssistantModel, AssistantTemperature } from "./assistant";
+import {
+  AssistantModel,
+  AssistantModelSchema,
+  AssistantTemperature,
+  AssistantTemperatureSchema,
+} from "./assistant";
 
 describe("assistant type values", () => {
   test("exposes supported assistant models", () => {
@@ -11,5 +16,22 @@ describe("assistant type values", () => {
       "BALANCED",
       "CREATIVE",
     ]);
+  });
+});
+
+describe("assistant schemas", () => {
+  test("accepts supported model values and rejects unknown ones", () => {
+    expect(AssistantModelSchema.safeParse(AssistantModel.FULL).success).toBe(
+      true,
+    );
+    expect(AssistantModelSchema.safeParse("gpt-5").success).toBe(false);
+  });
+
+  test("accepts supported temperature values and rejects unknown ones", () => {
+    expect(
+      AssistantTemperatureSchema.safeParse(AssistantTemperature.BALANCED)
+        .success,
+    ).toBe(true);
+    expect(AssistantTemperatureSchema.safeParse("HOT").success).toBe(false);
   });
 });

--- a/frontend/client/types/assistant.ts
+++ b/frontend/client/types/assistant.ts
@@ -1,16 +1,24 @@
+import { z } from "zod";
+
+export const AssistantModelSchema = z.enum(["gpt-4o", "gpt-4o-mini"]);
+
+export type AssistantModel = z.infer<typeof AssistantModelSchema>;
+
 export const AssistantModel = {
   FULL: "gpt-4o",
   MINI: "gpt-4o-mini",
-} as const;
+} as const satisfies Record<string, AssistantModel>;
 
-export type AssistantModel =
-  (typeof AssistantModel)[keyof typeof AssistantModel];
+export const AssistantTemperatureSchema = z.enum([
+  "DETERMINISTIC",
+  "BALANCED",
+  "CREATIVE",
+]);
+
+export type AssistantTemperature = z.infer<typeof AssistantTemperatureSchema>;
 
 export const AssistantTemperature = {
   DETERMINISTIC: "DETERMINISTIC",
   BALANCED: "BALANCED",
   CREATIVE: "CREATIVE",
-} as const;
-
-export type AssistantTemperature =
-  (typeof AssistantTemperature)[keyof typeof AssistantTemperature];
+} as const satisfies Record<string, AssistantTemperature>;

--- a/frontend/components/messages/ChatInput.test.tsx
+++ b/frontend/components/messages/ChatInput.test.tsx
@@ -87,6 +87,21 @@ describe("ChatInput component", () => {
     ).toBeVisible();
   });
 
+  test("rejects a message that exceeds the maximum length", () => {
+    const onSendMessageMock = vi.fn();
+    render(<ChatInput onSendMessage={onSendMessageMock} />);
+
+    fireEvent.change(screen.getByLabelText("Message"), {
+      target: { value: "x".repeat(32_001) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onSendMessageMock).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Message is too long (max 32,000 characters)."),
+    ).toBeVisible();
+  });
+
   test("send button is disabled when disabled prop is true", () => {
     const onSendMessageMock = vi.fn();
     render(

--- a/frontend/components/messages/ChatInput.tsx
+++ b/frontend/components/messages/ChatInput.tsx
@@ -2,11 +2,18 @@ import SendIcon from "@mui/icons-material/Send";
 import { Box, Button, CircularProgress, TextField } from "@mui/material";
 import type React from "react";
 import { type KeyboardEvent, useRef, useState } from "react";
+import {
+  ChatMessageTextSchema,
+  MAX_MESSAGE_CHARS,
+} from "@/client/chatConstants";
 
 interface ChatInputProps {
   onSendMessage: (message: string) => void | Promise<void>;
   disabled?: boolean;
 }
+
+const EMPTY_MESSAGE_ERROR = "Enter a message before sending.";
+const TOO_LONG_MESSAGE_ERROR = `Message is too long (max ${MAX_MESSAGE_CHARS.toLocaleString("en-US")} characters).`;
 
 const CHAT_INPUT_FORM_SX = {
   alignItems: "flex-start",
@@ -51,7 +58,7 @@ interface MessageFieldProps {
   inputRef: React.Ref<HTMLTextAreaElement>;
   disabled: boolean;
   message: string;
-  submittedEmpty: boolean;
+  validationError: string | null;
   onChange: (value: string) => void;
   onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
 }
@@ -60,7 +67,7 @@ function MessageField({
   inputRef,
   disabled,
   message,
-  submittedEmpty,
+  validationError,
   onChange,
   onKeyDown,
 }: MessageFieldProps) {
@@ -79,11 +86,10 @@ function MessageField({
       value={message}
       onChange={(e) => onChange(e.target.value)}
       onKeyDown={onKeyDown}
-      error={submittedEmpty}
+      error={validationError !== null}
       helperText={
-        submittedEmpty
-          ? "Enter a message before sending."
-          : "Press Enter for a new line. Press Ctrl+Enter or Cmd+Enter to send."
+        validationError ??
+        "Press Enter for a new line. Press Ctrl+Enter or Cmd+Enter to send."
       }
       sx={CHAT_INPUT_FIELD_SX}
     />
@@ -93,20 +99,25 @@ function MessageField({
 function ChatInput({ disabled = false, onSendMessage }: ChatInputProps) {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const [message, setMessage] = useState("");
-  const [submittedEmpty, setSubmittedEmpty] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   const sendMessage = async () => {
-    const trimmedMessage = message.trim();
+    // Same rule the server enforces, checked here for instant UX feedback.
+    const result = ChatMessageTextSchema.safeParse(message);
 
-    if (!trimmedMessage) {
-      setSubmittedEmpty(true);
+    if (!result.success) {
+      setValidationError(
+        message.trim().length === 0
+          ? EMPTY_MESSAGE_ERROR
+          : TOO_LONG_MESSAGE_ERROR,
+      );
       inputRef.current?.focus();
       return;
     }
 
-    setSubmittedEmpty(false);
+    setValidationError(null);
     setMessage("");
-    await onSendMessage(trimmedMessage);
+    await onSendMessage(result.data);
   };
 
   return (
@@ -122,10 +133,10 @@ function ChatInput({ disabled = false, onSendMessage }: ChatInputProps) {
         inputRef={inputRef}
         disabled={disabled}
         message={message}
-        submittedEmpty={submittedEmpty}
+        validationError={validationError}
         onChange={(value) => {
           setMessage(value);
-          if (submittedEmpty) setSubmittedEmpty(false);
+          if (validationError !== null) setValidationError(null);
         }}
         onKeyDown={(event) => {
           if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,8 @@
     "ai": "^7.0.14",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "zod": "^4.1.13"
   },
   "browserslist": {
     "production": [

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+      zod:
+        specifier: ^4.1.13
+        version: 4.4.3
     devDependencies:
       '@babel/core':
         specifier: ^8.0.1


### PR DESCRIPTION
## Summary

Applies the **["Parse, Don't Pray"](https://github.com/IndrajeetPatil/parse-dont-pray/blob/main/index.qmd)** advice for full-stack type safety: validate data at boundaries with schema libraries, on **both** the client (for UX / instant feedback) and the server (for security), using the **same rules** on each side, and keep configuration **immutable**.

### Where things stood
- **Backend** already exemplified the advice — Pydantic request models (`ChatRequest`/`UIMessage`/`TextPart`) with `Literal`/`StrEnum`/size caps/validators, and a validated `Settings`. The one recommendation not yet applied was **immutable config**.
- **Frontend** had *no* runtime-validation library at all — model/temperature were `as const` objects with inferred types, and user input was checked only with a manual `trim()`.

## Changes

### Backend
- `Settings` config is now **frozen** (`frozen=True`) — validate once at startup, use everywhere without re-checking (the article's *Immutable Configs* recommendation).
- Reworked the rate-limit test to swap the module-global `settings` instance (read by the limiter lambda at call time) instead of mutating the now-frozen object — arguably cleaner, no shared-state mutation.

### Frontend (introduces Zod)
- **Schema as single source of truth**: `AssistantModel` / `AssistantTemperature` are defined as Zod enum schemas with types **inferred** from them; the named const accessors (`.FULL`, `.MINI`, …) are kept for existing consumers and guarded against drift via `satisfies`.
- **Same rule on both sides**: a new `ChatMessageTextSchema` mirrors the backend's non-empty + 32,000-char limit. `ChatInput` validates with `safeParse` before sending, giving instant feedback (empty / too-long) **before** a server round-trip. The server still enforces the same rule for security.

### Deliberately *not* done
- No `extra="forbid"` on the request models: the trust boundary receives the Vercel AI SDK envelope (`id`/`trigger`/`messageId`, per-message `id`), which the backend must tolerate. Forbidding extras would 422 the live app, and there are no privilege-bearing fields, so mass-assignment risk is nil.
- No Zod schema for the outbound `{ model, temperature }` body — it comes from typed React state constrained by the dropdown options, so parsing our own local state would be ceremony.

## Verification (all local, green)
- `make qa` → **exit 0** (format, Ruff/Biome/rumdl/ESLint-security lint, `ty` + `tsc` type-check, type-coverage 100% both sides, ls-lint, Checkov, contrast audit, fallow, API-schema validation).
- **Backend**: 41 pytest tests, **100%** line+branch coverage.
- **Frontend**: 73 vitest tests — Stmts 96.99% / Branches 87.3% / Funcs 95.34% / Lines 98.41% (all above thresholds).
- **Playwright e2e**: 5/5 pass (API mocked via route interception), including the chat-input error-state visual regression.

---

## Follow-up: lean on libraries instead of hand-rolling

Reviewed whether the backend re-implements things `pydantic-settings` / `fastapi` already provide:

- **Removed redundant env aliases in `Settings`.** `pydantic-settings` maps each field to its upper-cased name as the env var (`AZURE_OPENAI_ENDPOINT`, `CHAT_RATE_LIMIT`, `TESTING`, …) case-insensitively and JSON-parses `list[str]` fields automatically — so `Field(alias="AZURE_OPENAI_ENDPOINT")` was just restating the library's default. Verified via the docs (*"Environment variable names default to the field name"*) and empirically. Dropped the aliases and plain-defaulted the scalar fields; tests now use field-name kwargs. Bonus: `alias` (vs `validation_alias`) had blocked init-by-field-name.
- **`chat_rate_limit` / `validate_azure_settings` validators kept** — these delegate to `limits.parse` and express genuine domain rules (the testing-mode bypass has no clean library equivalent), so they aren't hand-rolling.
- **FastAPI: no change.** The app already uses the framework's building blocks (`CORSMiddleware`, `StreamingResponse`, Pydantic request models, `slowapi` for rate limiting). `fastapi[standard]` is the right extra; switching to `fastapi[all]` would only pull in unused deps (orjson/ujson/pyyaml/itsdangerous/…), so it's intentionally left as-is.
