### PR TITLE
chore(frontend): import PR 176 tooling improvements

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
   "assist": {
     "actions": {
       "source": {
@@ -14,10 +15,13 @@
     "includes": [
       "**",
       "!**/.next",
+      "!**/.fallow",
+      "!**/.lighthouseci",
       "!**/coverage",
       "!**/dist",
       "!**/playwright-report",
       "!**/test-results",
+      "!**/tsconfig.tsbuildinfo",
       "!node_modules"
     ]
   },
@@ -34,10 +38,13 @@
     "includes": [
       "**",
       "!**/.next/**",
+      "!**/.fallow/**",
+      "!**/.lighthouseci/**",
       "!**/coverage/**",
       "!**/dist/**",
       "!**/playwright-report/**",
       "!**/test-results/**",
+      "!**/tsconfig.tsbuildinfo",
       "!node_modules/**"
     ]
   },
@@ -66,10 +73,13 @@
     "includes": [
       "**",
       "!**/.next/**",
+      "!**/.fallow/**",
+      "!**/.lighthouseci/**",
       "!**/coverage/**",
       "!**/dist/**",
       "!**/playwright-report/**",
       "!**/test-results/**",
+      "!**/tsconfig.tsbuildinfo",
       "!node_modules/**"
     ]
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "build": "rm -rf dist && vite build",
     "start": "vite preview --host 0.0.0.0 --port 3000",
     "check-types": "tsc --noemit",
-    "lint": "biome check --write --unsafe app client components e2e-tests src index.html *.json *.ts",
+    "lint": "biome check --write --unsafe --error-on-warnings biome.json package.json tsconfig.json eslint.config.js playwright.config.ts vite-env.d.ts vite.config.ts vitest.setup.ts .lighthouserc.json .fallowrc.json scripts/ app/ client/ components/ e2e-tests/ src/ index.html",
     "test": "vitest run --coverage",
     "test:update": "vitest run --update",
     "test:e2e": "npx playwright test",

--- a/frontend/scripts/contrast-audit.mjs
+++ b/frontend/scripts/contrast-audit.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * WCAG AA color-contrast audit for both UI color modes.
  *
@@ -10,8 +11,8 @@
 import { readFileSync, statSync } from "node:fs";
 import { createServer } from "node:http";
 import { extname, join, normalize } from "node:path";
-import axe from "axe-core";
 import { chromium } from "@playwright/test";
+import axe from "axe-core";
 
 const DIST = join(process.cwd(), "dist");
 
@@ -29,7 +30,9 @@ const MIME_TYPES = {
 };
 
 function existingFile(filePath) {
-  return statSync(filePath, { throwIfNoEntry: false })?.isFile() ? filePath : null;
+  return statSync(filePath, { throwIfNoEntry: false })?.isFile()
+    ? filePath
+    : null;
 }
 
 function routePath(pathname) {
@@ -60,7 +63,8 @@ function serveDist() {
     }
 
     res.writeHead(200, {
-      "content-type": MIME_TYPES[extname(filePath)] ?? "application/octet-stream",
+      "content-type":
+        MIME_TYPES[extname(filePath)] ?? "application/octet-stream",
     });
     res.end(readFileSync(filePath));
   });
@@ -74,12 +78,15 @@ async function auditMode(browser, baseUrl, mode) {
   const page = await browser.newPage({ colorScheme: mode });
   await page.goto(baseUrl, { waitUntil: "networkidle" });
   await page.addStyleTag({
-    content: "*,*::before,*::after{transition:none!important;animation:none!important}",
+    content:
+      "*,*::before,*::after{transition:none!important;animation:none!important}",
   });
   await page.addScriptTag({ content: axe.source });
 
   const violations = await page.evaluate(async () => {
-    const result = await window.axe.run(document, { runOnly: ["color-contrast"] });
+    const result = await window.axe.run(document, {
+      runOnly: ["color-contrast"],
+    });
     return result.violations.flatMap((violation) =>
       violation.nodes.map((node) => ({
         target: node.target.join(" "),

--- a/frontend/scripts/css-quality.mjs
+++ b/frontend/scripts/css-quality.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * CSS code quality checker using @projectwallace/css-code-quality.
  *
@@ -9,10 +10,10 @@
  * fonts are resolved at build time.
  */
 
+import { readFileSync } from "node:fs";
+import { glob } from "node:fs/promises";
+import { relative } from "node:path";
 import { calculate } from "@projectwallace/css-code-quality";
-import { readFileSync } from "fs";
-import { glob } from "fs/promises";
-import { relative } from "path";
 
 const THRESHOLDS = {
   maintainability: 80,


### PR DESCRIPTION
## Summary
- import the frontend/tooling improvements from `indrajeetpatil.github.io` PR [#176](https://github.com/IndrajeetPatil/indrajeetpatil.github.io/pull/176) that map cleanly to this React/Vite stack
- expand Biome lint coverage beyond app source files to include maintained config files and QA scripts, and fail the lint step on warnings
- bring the frontend QA scripts into compliance with the stricter lint boundary by using `node:` builtin imports and Biome-preferred formatting

## What Was Transferred
From website PR `#176`, the improvements that fit this repo were:
- broadening Biome coverage from just app code to maintained config and script files
- promoting Biome warnings to CI-failing lint results
- adding a concrete Biome schema reference and excluding generated frontend artifacts/caches from repo-wide traversal

Intentionally not transferred:
- Astro-specific TypeScript strictness changes (`astro check`, `astro/tsconfigs/strictest`)
- website-only `lychee.toml` hardening because this repo does not currently run a link-check target
- script and component fixes that were only needed for the website app itself

## Validation
- `pnpm run lint`
- `pnpm run check-types`
- `make qa`
