### PR TITLE
docs: sync repo docs with current tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,8 @@ streamed via Azure OpenAI GPT-4o.
 ## Setup
 
 ```bash
-cd backend && uv sync --frozen          # Python 3.14
-cd frontend && pnpm install --frozen-lockfile  # Node.js 24
+cd backend && uv sync --frozen          # Python 3.14, uv 0.11.28
+cd frontend && pnpm install --frozen-lockfile  # Node.js 24, pnpm 11.9.0
 ```
 
 Copy `backend/.env.example` → `backend/.env` and fill in
@@ -22,13 +22,16 @@ Azure OpenAI credentials before running.
 
 ```bash
 make update-deps # refresh backend/frontend deps and prek hook revisions
-make qa          # full suite: format, lint, type-check, test,
-                 #   coverage, security — run before every commit
+make qa          # full suite: format, lint, type-check, tests,
+                 #   coverage, API schema, frontend audits, security
 make tooling-check # verify agent/copilot symlink wiring
 make test        # unit tests only
 make format      # auto-format (Ruff + Biome)
 make lint        # lint (Ruff + Biome + rumdl; ESLint runs via make qa)
 make type-check  # static types (ty + tsc)
+make contrast-audit # built frontend contrast audit in light/dark mode
+make lighthouse  # Lighthouse CI assertions against the built frontend
+make docker-build # build both service images with Docker Compose
 make run         # start both servers
                  #   frontend :3000, backend :8000, Swagger :8000/docs
 docker-compose up

--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ REST API can be interactively explored using FastAPI's Swagger UI:
 
 ## Runtime Versions
 
-| Runtime / tool | Version source | Current major |
-|----------------|----------------|---------------|
-| Python         | `backend/.python-version` / `backend/pyproject.toml` | 3 |
-| uv             | `backend/pyproject.toml` / `backend/Dockerfile` | 0 |
+| Runtime / tool | Version source | Current version |
+|----------------|----------------|-----------------|
+| Python         | `backend/.python-version` / `backend/pyproject.toml` | 3.14 |
+| uv             | `backend/pyproject.toml` / `backend/Dockerfile` | 0.11.28 |
 | Node.js        | `frontend/.nvmrc` / frontend Docker image | 24 |
-| pnpm           | `frontend/package.json` / CI workflows | 11 |
+| pnpm           | `frontend/package.json` / CI workflows | 11.9.0 |
 
 ## Quality Assurance
 


### PR DESCRIPTION
## Summary
- align `README.md` runtime docs with the exact versions currently pinned in source
- align `AGENTS.md` setup comments with the pinned `uv` and `pnpm` versions
- expand the `AGENTS.md` command list so the documented QA surface matches the actual Make targets in this repo

## Validation
- `uv tool run --from rumdl==0.1.86 rumdl check README.md AGENTS.md`
- `git diff --check`
- `make tooling-check`
