### PR TITLE
ci: harden security and add continuous scanning

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0

--- a/.github/workflows/prek.yaml
+++ b/.github/workflows/prek.yaml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Run prek
         uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d  # v2.0.5

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,11 +17,89 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  checkov:
+  secret-scan:
+    name: Secret Scan (Gitleaks)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: "false"
+
+  workflow-audit:
+    name: Workflow Audit (zizmor)
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+
+      - name: Run zizmor
+        run: uvx zizmor@1.27.0 .github/workflows/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  frontend-audit:
+    name: Dependency Audit (pnpm)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+        with:
+          package_json_file: frontend/package.json
+
+      - name: Audit production dependencies
+        working-directory: ./frontend
+        run: pnpm audit --prod
+
+  backend-audit:
+    name: Dependency Audit (uv)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+        with:
+          working-directory: ./backend
+
+      # Runtime dependencies are the merge gate. Development-only advisories
+      # remain visible through Dependabot and are triaged separately because
+      # they are not deployed with the service.
+      - name: Audit locked production dependencies
+        working-directory: ./backend
+        run: uv audit --locked --no-dev --preview-features audit-command
+
+  checkov:
+    name: Infrastructure Scan (Checkov)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
@@ -60,6 +62,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
@@ -106,6 +110,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Verify repo tooling symlinks
         run: make tooling-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ make test        # unit tests only
 make format      # auto-format (Ruff + Biome)
 make lint        # lint (Ruff + Biome + rumdl; ESLint runs via make qa)
 make type-check  # static types (ty + tsc)
+make security-scan # Checkov scan of Docker and GitHub Actions configuration
 make contrast-audit # built frontend contrast audit in light/dark mode
 make lighthouse  # Lighthouse CI assertions against the built frontend
 make docker-build # build both service images with Docker Compose
@@ -36,6 +37,10 @@ make run         # start both servers
                  #   frontend :3000, backend :8000, Swagger :8000/docs
 docker-compose up
 ```
+
+The CI-only Security Scan workflow adds full-history Gitleaks, online zizmor,
+and production dependency audits on pushes, pull requests, weekly schedules,
+and manual dispatches.
 
 Unless explicitly requested, do not wait for CI/CD checks to finish after
 pushing. Report that the checks were triggered and include the relevant PR or

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ More specifically:
 | Pre-commit hooks          | prek                             | prek                      |
 | Commit message linting    | commitlint                       | commitlint                |
 | IaC / workflow scan       | Checkov                          | Checkov                   |
+| Secret scanning           | Gitleaks                         | Gitleaks                  |
+| GitHub Actions audit      | zizmor                           | zizmor                    |
 | Container vuln scan       | Trivy                            | Trivy                     |
 | Unit testing              | Vitest                           | pytest                    |
 | Property-based testing    | fast-check                       | Hypothesis                |
@@ -197,9 +199,11 @@ and must not be committed:
 make security-scan
 ```
 
-The Checkov scan also runs on every push and pull request through the
-dedicated GitHub Actions security workflow. Commitlint is enforced locally
-through the `commit-msg` prek hook.
+The dedicated GitHub Actions security workflow runs Checkov, a full-history
+Gitleaks secret scan, an online zizmor workflow audit, and production dependency
+audits on every push and pull request. It also runs weekly and supports manual
+dispatch so newly disclosed issues surface even when the repository has not
+changed. Commitlint is enforced locally through the `commit-msg` prek hook.
 
 Trivy scans the built backend and frontend container images for known
 vulnerabilities during CI.

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,23 +1,3 @@
 allowBuilds:
   fallow: true
-
-# Quarantine newly published packages for 24 hours before resolving them. Frozen
-# installs verify the policy too, so exact versions already reviewed on main are
-# exempted below; future dependency updates wait out the highest-risk window.
-minimumReleaseAge: 1440
-minimumReleaseAgeExclude:
-  - "@ai-sdk/gateway@4.0.20"
-  - "@ai-sdk/mcp@2.0.13"
-  - "@ai-sdk/provider-utils@5.0.10"
-  - "@ai-sdk/react@4.0.30"
-  - "@fallow-cli/darwin-arm64@3.5.1"
-  - "@fallow-cli/darwin-x64@3.5.1"
-  - "@fallow-cli/linux-arm64-gnu@3.5.1"
-  - "@fallow-cli/linux-arm64-musl@3.5.1"
-  - "@fallow-cli/linux-x64-gnu@3.5.1"
-  - "@fallow-cli/linux-x64-musl@3.5.1"
-  - "@fallow-cli/win32-arm64-msvc@3.5.1"
-  - "@fallow-cli/win32-x64-msvc@3.5.1"
-  - "ai@7.0.28"
-  - "electron-to-chromium@1.5.392"
-  - "fallow@3.5.1"
+minimumReleaseAge: 0

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,23 @@
 allowBuilds:
   fallow: true
-minimumReleaseAge: 0
+
+# Quarantine newly published packages for 24 hours before resolving them. Frozen
+# installs verify the policy too, so exact versions already reviewed on main are
+# exempted below; future dependency updates wait out the highest-risk window.
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - "@ai-sdk/gateway@4.0.20"
+  - "@ai-sdk/mcp@2.0.13"
+  - "@ai-sdk/provider-utils@5.0.10"
+  - "@ai-sdk/react@4.0.30"
+  - "@fallow-cli/darwin-arm64@3.5.1"
+  - "@fallow-cli/darwin-x64@3.5.1"
+  - "@fallow-cli/linux-arm64-gnu@3.5.1"
+  - "@fallow-cli/linux-arm64-musl@3.5.1"
+  - "@fallow-cli/linux-x64-gnu@3.5.1"
+  - "@fallow-cli/linux-x64-musl@3.5.1"
+  - "@fallow-cli/win32-arm64-msvc@3.5.1"
+  - "@fallow-cli/win32-x64-msvc@3.5.1"
+  - "ai@7.0.28"
+  - "electron-to-chromium@1.5.392"
+  - "fallow@3.5.1"


### PR DESCRIPTION
## Summary

- disable persisted checkout credentials in every workflow job that does not push
- expand the existing security workflow with full-history Gitleaks scanning, online zizmor workflow auditing, and production dependency audits for pnpm and uv
- run security scanning weekly and on demand in addition to pull requests and pushes to `main`
- document the expanded security workflow in README and AGENTS.md

## Why

This ports the stack-compatible security hardening from `indrajeetpatil.github.io` commit `01fec0433c4b5d966da89503d6eb0d0bf2ddd9c4`. The Sentry and Google Analytics changes are website-specific and were intentionally excluded. This project also deliberately retains `minimumReleaseAge: 0` so fresh dependency updates do not break frozen installs.

The checkout changes prevent third-party build and test steps from inheriting a persisted Git credential. Scheduled scans also catch newly disclosed advisories and workflow issues even when the repository has not changed.

The uv gate covers deployed backend dependencies. A development-only `typecoverage -> replit -> protobuf<5` chain currently cannot take the protobuf 5/6 fix, so development tooling remains outside this merge gate.

## Validation

- `make qa`
- `gitleaks detect --source . --log-opts="--all" --no-banner --redact`
- `GH_TOKEN=... uvx zizmor@1.27.0 .github/workflows/`
- `pnpm install --frozen-lockfile`
- `pnpm audit --prod`
- `uv audit --locked --no-dev --preview-features audit-command`
- `make security-scan`
- `uv tool run --from rumdl==0.1.86 rumdl check README.md AGENTS.md`
- `make tooling-check`
