### PR TITLE
docs: trim stale code-quality eval findings

### DIFF
--- a/code-quality-evals/gpt-55-review.md
+++ b/code-quality-evals/gpt-55-review.md
@@ -2,6 +2,9 @@
 
 ## Ratings
 
+These ratings are preserved from the original review; the sections below track
+only findings that remain actionable on the current codebase.
+
 | Dimension | Score |
 | --- | --- |
 | Template quality | 8.2 / 10 |
@@ -25,11 +28,3 @@
 
 1. Add request IDs and structured backend metadata, including token usage,
    finish reasons, and cancellation signals.
-2. Add frontend telemetry for failed submissions, aborted streams, retry rates,
-   and user-perceived latency.
-
-## LLM evaluation coverage
-
-1. Add a minimal LLM eval suite with a golden prompt set, safety probes,
-   jailbreak or prompt-injection checks, hallucination checks, regression
-   prompts, and cost or latency budgets.

--- a/code-quality-evals/opus-47-review.md
+++ b/code-quality-evals/opus-47-review.md
@@ -2,6 +2,9 @@
 
 ## Ratings
 
+These ratings are preserved from the original review; the sections below track
+only findings that remain actionable on the current codebase.
+
 | Dimension | Score | One-line rationale |
 | --- | --- | --- |
 | Readability | 9.0 | Short files, strict complexity ceiling, clear names |
@@ -20,51 +23,20 @@
 
 1. Generate a shared API contract from FastAPI's OpenAPI output and consume it
    on the frontend to reduce schema drift risk.
-2. Split backend routes into a `routers/` structure before `main.py` becomes a
-   larger catch-all module.
-
-## Testing
-
-1. Raise frontend branch coverage, especially around streaming error behavior.
 
 ## Error handling and resilience
 
-1. Add client retry or backoff behavior for transient rate-limit failures.
-2. Add a circuit breaker around Azure OpenAI failures.
-3. Surface Azure SDK retries in logs, or make retry behavior more explicit to
-   operators.
-4. Surface streaming failures to the frontend with a sentinel token, trailer,
+1. Surface streaming failures to the frontend with a sentinel token, trailer,
    or equivalent contract instead of relying on truncated responses.
-5. Stop silently dropping whitespace-only messages inside mixed requests;
+2. Stop silently dropping whitespace-only messages inside mixed requests;
    either reject them consistently or log the discard explicitly.
-6. Make `max_retries` configurable through settings instead of hard-coding it.
-7. Set an explicit Azure client timeout instead of relying on the SDK default.
-8. Document or refactor Azure client caching so test isolation and worker
-   behavior are explicit.
+3. Set an explicit Azure client timeout instead of relying on the SDK default.
 
 ## Security and configuration
 
-1. Tighten or explicitly justify wildcard CORS methods and headers.
-2. Document `CORS_ALLOWED_ORIGINS` clearly in `.env.example` and fail startup
+1. Document `CORS_ALLOWED_ORIGINS` clearly in `.env.example` and fail startup
    in production if it is not set appropriately.
-
-## Documentation
-
-1. Add ADRs for non-obvious architectural choices.
-2. Add API request and response examples beyond Swagger.
-3. Add short docstrings to nuanced tests where the contract is not obvious.
 
 ## Performance and observability
 
 1. Log token usage instead of relying on returned-character counts.
-2. Evaluate whether repeated-prompt caching is worthwhile for development or
-   demo scenarios.
-3. Make the frontend throttle value configurable instead of hard-coded.
-4. Add an explicit frontend bundle-size or performance budget in CI.
-
-## Dependency hygiene
-
-1. Decide whether Python dependencies need upper bounds in addition to the
-   lockfile and document that policy clearly.
-2. Consider adding backend dead-code detection beyond Ruff's unused-import
-   checks.


### PR DESCRIPTION
## Summary

- remove resolved or low-value findings from both code-quality evaluations
- retain the remaining production-boundary, streaming, contract, timeout, CORS, and observability concerns
- clarify that the rating tables are preserved from the original reviews while the actionable lists track the current codebase

## Why

The evaluation files had accumulated recommendations that are now covered by the repository's tests and Lighthouse budgets or are disproportionate for a small chatbot template, such as extra retry layers, circuit breakers, ADRs, prompt caching, configurable UI throttling, dependency upper bounds, and additional dead-code tooling.

## Impact

The files now work as concise backlogs of current, material gaps instead of mixing active findings with resolved or low-priority suggestions. There is no runtime behavior change.

## Validation

- `make markdown-lint`
- commit-time prek hooks
- push-time prek hooks