### PR TITLE
Remove obsolete Copilot instructions file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,0 @@
-../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,8 @@
 # Chatbot Template
 
 Project-level instructions for AI coding agents working on this repository.
-Codex and other `AGENTS.md`-aware tools read this file directly; GitHub Copilot
-reads it via `.github/copilot-instructions.md`, which should remain a symlink to
-this file.
+Codex, GitHub Copilot (code review and coding agent), and other
+`AGENTS.md`-aware tools read this file directly.
 
 Full-stack chatbot: React frontend + FastAPI backend,
 streamed via Azure OpenAI GPT-4o.
@@ -24,7 +23,7 @@ Azure OpenAI credentials before running.
 make update-deps # refresh backend/frontend deps and prek hook revisions
 make qa          # full suite: format, lint, type-check, tests,
                  #   coverage, API schema, frontend audits, security
-make tooling-check # verify agent/copilot symlink wiring
+make tooling-check # verify agent skill symlink wiring
 make test        # unit tests only
 make format      # auto-format (Ruff + Biome)
 make lint        # lint (Ruff + Biome + rumdl; ESLint runs via make qa)

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ lighthouse: frontend-build frontend-lighthouse
 
 # Project-wide tools
 tooling-check:
-	@echo "$(COLOR_BLUE_BG)Checking repo tooling symlinks...$(COLOR_RESET)"
+	@echo "$(COLOR_BLUE_BG)Checking agent skill symlinks...$(COLOR_RESET)"
 	python3 scripts/check-repo-symlinks.py
 
 commitlint:

--- a/scripts/check-repo-symlinks.py
+++ b/scripts/check-repo-symlinks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify repo-level symlink wiring for agent tooling."""
+"""Verify shared skill symlink wiring for agent tooling."""
 
 from __future__ import annotations
 
@@ -9,8 +9,6 @@ import sys
 REPO_ROOT = Path(__file__).resolve().parent.parent
 AGENTS_SKILLS = REPO_ROOT / ".agents" / "skills"
 CLAUDE_SKILLS = REPO_ROOT / ".claude" / "skills"
-COPILOT_LINK = REPO_ROOT / ".github" / "copilot-instructions.md"
-AGENTS_FILE = REPO_ROOT / "AGENTS.md"
 
 
 def fail(message: str) -> None:
@@ -51,17 +49,9 @@ def check_claude_skill_symlinks() -> None:
             fail(f".claude/skills/{entry.name} has no matching .agents/skills entry")
 
 
-def check_copilot_instructions_symlink() -> None:
-    if not COPILOT_LINK.is_symlink():
-        fail(".github/copilot-instructions.md must be a symlink to ../AGENTS.md")
-    if COPILOT_LINK.resolve() != AGENTS_FILE.resolve():
-        fail(".github/copilot-instructions.md does not resolve to AGENTS.md")
-
-
 def main() -> None:
     check_claude_skill_symlinks()
-    check_copilot_instructions_symlink()
-    print("Repo tooling symlinks OK.")
+    print("Agent skill symlinks OK.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- remove the obsolete `.github/copilot-instructions.md` symlink
- retain the root `AGENTS.md` as the single source of repository instructions
- remove the obsolete Copilot-link assertion from the repository symlink checker while preserving the agent-skill symlink checks
- update related documentation and command output

## Why

GitHub Copilot Code Review now supports agent instructions from a root `AGENTS.md` file directly, so the symlink is no longer necessary.

Documentation: https://docs.github.com/en/copilot/reference/custom-instructions-support

## Validation

- `git diff --check`
- `make tooling-check`
- Python syntax compilation for `scripts/check-repo-symlinks.py`
- confirmed `AGENTS.md` remains present and `.github/copilot-instructions.md` is removed
