### PR TITLE
fix(security): harden message limits, Trivy pin, and CI secret exposure

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -34,14 +34,17 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends ca-certificates curl
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin "$TRIVY_VERSION"
+          curl -sfL "https://raw.githubusercontent.com/aquasecurity/trivy/${TRIVY_VERSION}/contrib/install.sh" | sudo sh -s -- -b /usr/local/bin "$TRIVY_VERSION"
           trivy --version
 
       - name: Create .env file
+        # This job only smoke-tests that the containers build and start; it never
+        # issues a chat request, so no real Azure credentials are needed. Using
+        # dummy placeholders keeps secrets out of PR-controlled build/run steps.
         run: |
-          echo AZURE_OPENAI_ENDPOINT=${{ secrets.AZURE_OPENAI_ENDPOINT }} >> backend/.env
-          echo AZURE_OPENAI_API_KEY=${{ secrets.AZURE_OPENAI_API_KEY }} >> backend/.env
-          echo AZURE_OPENAI_API_VERSION=${{ secrets.AZURE_OPENAI_API_VERSION }} >> backend/.env
+          echo AZURE_OPENAI_ENDPOINT=https://example.invalid/ >> backend/.env
+          echo AZURE_OPENAI_API_KEY=dummy-key >> backend/.env
+          echo AZURE_OPENAI_API_VERSION=2024-09-01-preview >> backend/.env
 
       - name: Build services
         run: |

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -74,8 +74,15 @@ class UIMessage(BaseModel):
             raise ValueError(msg)
         # Each part is capped individually, but the joined result must also stay
         # within the per-message limit so a request can't concatenate many parts
-        # into an oversized payload forwarded to Azure.
-        if len(self.text) > _MAX_MESSAGE_CHARS:
+        # into an oversized payload forwarded to Azure. Sum the part lengths
+        # instead of len(self.text) so an abusive payload is rejected without
+        # first materializing the fully-joined string.
+        aggregate_len: int = (
+            len(self.content)
+            if self.content is not None
+            else sum(len(part.text) for part in self.parts)
+        )
+        if aggregate_len > _MAX_MESSAGE_CHARS:
             msg = (
                 f"Joined message text must not exceed {_MAX_MESSAGE_CHARS} characters."
             )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 _MAX_MESSAGES = 50
 _MAX_MESSAGE_CHARS = 32_000
+_MAX_PARTS = 50
 
 settings: Settings = get_settings()
 
@@ -64,12 +65,20 @@ def _parse_message_text(content: str | None, parts: list[TextPart]) -> str:
 class UIMessage(BaseModel):
     role: OpenAIMessageRole
     content: str | None = Field(default=None, max_length=_MAX_MESSAGE_CHARS)
-    parts: list[TextPart] = Field(default_factory=list)
+    parts: list[TextPart] = Field(default_factory=list, max_length=_MAX_PARTS)
 
     @model_validator(mode="after")
     def validate_content_or_parts(self) -> UIMessage:
         if self.content is None and not self.parts:
             msg: str = "At least one of 'content' or 'parts' must be provided."
+            raise ValueError(msg)
+        # Each part is capped individually, but the joined result must also stay
+        # within the per-message limit so a request can't concatenate many parts
+        # into an oversized payload forwarded to Azure.
+        if len(self.text) > _MAX_MESSAGE_CHARS:
+            msg = (
+                f"Joined message text must not exceed {_MAX_MESSAGE_CHARS} characters."
+            )
             raise ValueError(msg)
         return self
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -155,6 +155,40 @@ def test_post_chat_rejects_message_content_too_long(client: TestClient) -> None:
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
+def test_post_chat_rejects_too_many_parts(client: TestClient) -> None:
+    response: TestClientResponse = client.post(
+        "/api/v1/chat",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "parts": [{"type": "text", "text": "x"}] * 51,
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+def test_post_chat_rejects_aggregate_parts_too_long(client: TestClient) -> None:
+    response: TestClientResponse = client.post(
+        "/api/v1/chat",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    # 4 parts of 10_000 chars = 40_000 > _MAX_MESSAGE_CHARS, even
+                    # though each individual part is within the per-part cap.
+                    "parts": [{"type": "text", "text": "x" * 10_000}] * 4,
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
 def test_chat_endpoint_rate_limits_after_threshold(
     monkeypatch: pytest.MonkeyPatch,
     client: TestClient,
@@ -210,6 +244,17 @@ def test_ui_message_rejects_empty_content_and_parts() -> None:
         match="At least one of 'content' or 'parts' must be provided",
     ):
         UIMessage(role=OpenAIMessageRole.USER)
+
+
+def test_ui_message_rejects_aggregate_parts_too_long() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="Joined message text must not exceed",
+    ):
+        UIMessage(
+            role=OpenAIMessageRole.USER,
+            parts=[TextPart(type="text", text="x" * 10_000)] * 4,
+        )
 
 
 def test_stream_chat_reraises_non_openai_exception(


### PR DESCRIPTION
## Summary

Addresses the actionable findings from the `codex-security` repository scan that are meaningful for this public, rate-limited chatbot template. Each fix is small and preserves existing behavior for legitimate use.

### Fixes

**1. Bound aggregate message parts** (finding #5 — CWE-400/770, medium)
`UIMessage.parts` previously had no count or aggregate-size limit — each part was capped at 32k chars, but the number of parts was unbounded, so a single request could join arbitrarily large text and forward it to Azure (memory/CPU/cost pressure). Now the list is capped at `_MAX_PARTS = 50` and the joined text is validated against the existing per-message character limit. Returns `422` on violation.

**2. Pin Trivy installer to an immutable tag** (finding #3 — CWE-494/829, medium)
The Docker CI workflow fetched `install.sh` from Trivy's mutable `main` branch and piped it to `sudo sh`. It now fetches the script from the same immutable version tag (`$TRIVY_VERSION`) already used to pin the installed binary.

**3. Keep Azure secrets out of PR builds** (finding #4 — CWE-200, medium)
The `docker-compose` workflow only smoke-tests that containers build and start — it never issues a chat request, so real Azure credentials were never exercised. Replaced them with dummy placeholders so PR-controlled build/run steps can't exfiltrate secrets.

### Deliberately not changed

- **uv dev-container installer (#1)** — official install method; version is verified after install.
- **prek hook tags (#2)** — tag pinning is the conventional pre-commit workflow; SHA-pinning adds maintenance friction with little benefit for a solo repo.
- **Unauthenticated chat API (#6)** — intentional for a public chatbot; already protected by per-IP rate limiting.

### Testing

- Added `test_post_chat_rejects_too_many_parts`, `test_post_chat_rejects_aggregate_parts_too_long`, and `test_ui_message_rejects_aggregate_parts_too_long`.
- `pytest tests/test_main.py` — 20 passed.
- All prek hooks pass (ruff, ty, format).